### PR TITLE
LPS-54798 Make vocabulary and category names required when creating them

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/META-INF/resources/edit_category.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/META-INF/resources/edit_category.jsp
@@ -103,7 +103,7 @@ else {
 	<aui:model-context bean="<%= category %>" model="<%= AssetCategory.class %>" />
 
 	<aui:fieldset>
-		<aui:input autoFocus="<%= true %>" label="name" name="title" />
+		<aui:input autoFocus="<%= true %>" label="name" name="title" required="<%= true %>" />
 
 		<aui:input name="description" />
 

--- a/modules/apps/asset/asset-categories-admin-web/src/META-INF/resources/edit_vocabulary.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/META-INF/resources/edit_vocabulary.jsp
@@ -54,7 +54,7 @@ if (vocabularyId > 0) {
 	<aui:fieldset>
 		<div>
 			<div class="add-vocabulary-layer asset-category-layer">
-				<aui:input autoFocus="<%= true %>" label="name" name="title" />
+				<aui:input autoFocus="<%= true %>" label="name" name="title" required="<%= true %>" />
 
 				<aui:input name="description" />
 


### PR DESCRIPTION
Jurgen, el cambio que has hecho está genial.

Pero aparte de eso, veo que el problema se ha originado porque al haber el error se manda al usuario a la vista principal. Antes se quedaba en la vista de edición y ahí sí que hay un mensaje más claro.

Puedes mirar a ver si solucionamos eso también? y luego aparte dejamos tu cambio que hace la cosa aún mejor, claro.....