### PR TITLE
LPS-56702 Fix test: use service name instead of portlet id, since we are using group configuration and the new settings framework

### DIFF
--- a/modules/apps/journal/journal-test/test/integration/com/liferay/journal/subscriptions/test/JournalSubscriptionLocalizedContentTest.java
+++ b/modules/apps/journal/journal-test/test/integration/com/liferay/journal/subscriptions/test/JournalSubscriptionLocalizedContentTest.java
@@ -15,6 +15,7 @@
 package com.liferay.journal.subscriptions.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.journal.constants.JournalConstants;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.service.JournalArticleLocalServiceUtil;
 import com.liferay.journal.service.JournalFolderLocalServiceUtil;
@@ -85,6 +86,11 @@ public class JournalSubscriptionLocalizedContentTest
 	}
 
 	@Override
+	protected String getServiceName() {
+		return JournalConstants.SERVICE_NAME;
+	}
+
+	@Override
 	protected String getSubscriptionAddedBodyPreferenceName() {
 		return "emailArticleAddedBody";
 	}
@@ -101,7 +107,7 @@ public class JournalSubscriptionLocalizedContentTest
 
 		PortletPreferences portletPreferences =
 			PortletPreferencesFactoryUtil.getStrictPortletSetup(
-				layout, getPortletId());
+				layout, getServiceName());
 
 		LocalizationUtil.setPreferencesValue(
 			portletPreferences, bodyPreferenceName,
@@ -112,7 +118,8 @@ public class JournalSubscriptionLocalizedContentTest
 
 		PortletPreferencesLocalServiceUtil.updatePreferences(
 			group.getGroupId(), PortletKeys.PREFS_OWNER_TYPE_GROUP,
-			PortletKeys.PREFS_PLID_SHARED, getPortletId(), portletPreferences);
+			PortletKeys.PREFS_PLID_SHARED, getServiceName(),
+			portletPreferences);
 	}
 
 	@Override


### PR DESCRIPTION
Just a test to check that no test errors are thrown