### PR TITLE
LPS-73914 Get categories using filtered persistence methods

### DIFF
--- a/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/asset_categories_selector.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/asset_categories_selector.js
@@ -272,6 +272,7 @@ AUI.add(
 						var data = {};
 
 						data.p_auth = Liferay.authToken;
+						data.scopeGroupId = themeDisplay.getScopeGroupId();
 
 						var assetId = instance._getTreeNodeAssetId(treeNode);
 						var assetType = instance._getTreeNodeAssetType(treeNode);
@@ -279,6 +280,10 @@ AUI.add(
 						if (Lang.isValue(assetId)) {
 							if (assetType == 'category') {
 								data.categoryId = assetId;
+								var vocabularyId = instance._getTreeNodeVocabularyId(treeNode);
+								if (vocabularyId) {
+									data.vocabularyId = vocabularyId;
+								}
 							}
 							else {
 								data.vocabularyId = assetId;
@@ -378,6 +383,22 @@ AUI.add(
 						var match = treeId.match(/^(vocabulary|category)/);
 
 						return match ? match[1] : null;
+					},
+
+					_getTreeNodeVocabularyId: function(treeNode) {
+						var instance = this;
+
+						var parentNode = treeNode.get('parentNode');
+						var ancestorNode = parentNode.get('parentNode');
+
+						while (ancestorNode.get('parentNode')) {
+							parentNode = ancestorNode;
+							ancestorNode = ancestorNode.get('parentNode');
+						}
+
+						var parentId = instance._getTreeNodeAssetId(parentNode);
+						var parentType = instance._getTreeNodeAssetType(parentNode);
+						return parentType == 'vocabulary'? parentId : null;
 					},
 
 					_initSearch: EMPTY_FN,

--- a/portal-impl/src/com/liferay/portlet/asset/action/GetCategoriesAction.java
+++ b/portal-impl/src/com/liferay/portlet/asset/action/GetCategoriesAction.java
@@ -76,20 +76,34 @@ public class GetCategoriesAction extends JSONAction {
 		long vocabularyId = ParamUtil.getLong(request, "vocabularyId");
 		int start = ParamUtil.getInteger(request, "start", QueryUtil.ALL_POS);
 		int end = ParamUtil.getInteger(request, "end", QueryUtil.ALL_POS);
+		long scopeGroupId = ParamUtil.getLong(request, "scopeGroupId");
 
 		List<AssetCategory> categories = Collections.emptyList();
 
 		if (categoryId > 0) {
-			categories = AssetCategoryServiceUtil.getChildCategories(
-				categoryId, start, end, null);
+			if (scopeGroupId > 0) {
+				categories = AssetCategoryServiceUtil.getVocabularyCategories(
+					scopeGroupId, categoryId, vocabularyId, start, end, null);
+			} else
+			{
+				categories = AssetCategoryServiceUtil.getChildCategories(
+					categoryId, start, end, null);
+			}
 		}
 		else if (vocabularyId > 0) {
 			long parentCategoryId = ParamUtil.getLong(
 				request, "parentCategoryId",
 				AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID);
 
-			categories = AssetCategoryServiceUtil.getVocabularyCategories(
-				parentCategoryId, vocabularyId, start, end, null);
+			if (scopeGroupId > 0) {
+				categories = AssetCategoryServiceUtil.getVocabularyCategories(
+					scopeGroupId, parentCategoryId, vocabularyId, start, end,
+					null);
+			} else
+			{
+				categories = AssetCategoryServiceUtil.getVocabularyCategories(
+					parentCategoryId, vocabularyId, start, end, null);
+			}
 		}
 
 		return categories;


### PR DESCRIPTION
This bug isn't reproducible on master. Master uses AssetCategoriesSelectorPortlet(LPS-67066) to add categories to a content but 7.0.x and 6.2.x use an AlloyUI's input. Because of this I created a test portlet to test it on master (see LPS). The reason I'm uploading this in master is because the code is still in there although it is not used. Maybe it would be interesting to deprecate the unused "com.liferay.portlet.asset.action.GetCategoriesAction".

In case you are wondering why in "com.liferay.portlet.asset.action.GetCategoriesAction.getCategories" there is a mismatch between the calls "getVocabularyCategories" and "getChildCategories", that is because there is no "getChildCategories" method that queries the data using inline SQL permission checks which I need so that the results are paginated properly.