### PR TITLE
Updated MSBFragmentNameEditor for fragment updating

### DIFF
--- a/modules/apps/web-experience/modern-site-building/modern-site-building-fragment-web/src/main/resources/META-INF/resources/js/MSBFragmentNameEditor.js
+++ b/modules/apps/web-experience/modern-site-building/modern-site-building-fragment-web/src/main/resources/META-INF/resources/js/MSBFragmentNameEditor.js
@@ -40,7 +40,10 @@ class MSBFragmentNameEditor extends Component {
 			.then((jsonResponse) => {
 				this.error = jsonResponse.error;
 
-				if (jsonResponse.msbFragmentEntryId) {
+				if (
+					jsonResponse.msbFragmentEntryId &&
+					this.editMSBFragmentEntryURL
+				) {
 					const uri = new Uri(this.editMSBFragmentEntryURL);
 
 					uri.addParameterValue(
@@ -56,6 +59,8 @@ class MSBFragmentNameEditor extends Component {
 					} else {
 						location.href = uriString;
 					}
+				} else if (!this.error) {
+					this.disposeInternal();
 				}
 			});
 	}
@@ -96,6 +101,27 @@ MSBFragmentNameEditor.STATE = {
 	 * @type {?string}
 	 */
 	error: Config.string().value(''),
+
+	/**
+	 * When specified, this value will be sent within the formData,
+	 * so an existing fragment can be edited instead of creating a new one.
+	 * @default ''
+	 * @instance
+	 * @memberOf MSBFragmentNameEditor
+	 * @type {?string}
+	 */
+	fragmentEntryId: Config.string().value(''),
+
+	/**
+	 * Initial name of the fragment.
+	 * This value should be specified if the fragment has already
+	 * been created.
+	 * @default ''
+	 * @instance
+	 * @memberOf MSBFragmentNameEditor
+	 * @type {?string}
+	 */
+	initialName: Config.string().value(''),
 
 	/**
 	 * Portlet namespace needed for prefixing form inputs

--- a/modules/apps/web-experience/modern-site-building/modern-site-building-fragment-web/src/main/resources/META-INF/resources/js/MSBFragmentNameEditor.soy
+++ b/modules/apps/web-experience/modern-site-building/modern-site-building-fragment-web/src/main/resources/META-INF/resources/js/MSBFragmentNameEditor.soy
@@ -9,6 +9,8 @@
 	{@param? _handleModalHidden: any}
 	{@param? _handleSubmitForm: any}
 	{@param? error: string}
+	{@param? fragmentEntryId: string}
+	{@param? initialValue: string}
 
 	{call Modal.render}
 		{param body kind="html"}
@@ -33,7 +35,20 @@
 						<span class="hide-accessible">{msg desc=""}required{/msg}</span>
 					</label>
 
-					<input class="field form-control" name="{$namespace}name" type="text">
+					{if $fragmentEntryId}
+						<input
+							name="{$namespace}msbFragmentEntryId"
+							type="hidden"
+							value="{$fragmentEntryId}"
+						>
+					{/if}
+
+					<input
+						class="field form-control"
+						name="{$namespace}name"
+						type="text"
+						value="{$initialValue}"
+					>
 
 					{if $error}
 						<div class="form-validator-stack help-block">


### PR DESCRIPTION
Now a fragmentEntryId and an initialValue attributes can be specified
for updating an existing fragment instead of creating a new one