### PR TITLE
[TECHNICAL-SUPPORT] LPS-87577 AssetDisplayPageEntry upgrade

### DIFF
--- a/modules/apps/asset/asset-display-page-service/build.gradle
+++ b/modules/apps/asset/asset-display-page-service/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly project(":apps:asset:asset-display-page-api")
 	compileOnly project(":apps:export-import:export-import-api")
+	compileOnly project(":apps:journal:journal-api")
 	compileOnly project(":apps:portal:portal-spring-extender-api")
 	compileOnly project(":apps:portal:portal-upgrade-api")
 	compileOnly project(":apps:xstream:xstream-configurator-api")

--- a/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/internal/upgrade/AssetDisplayPageServiceUpgrade.java
+++ b/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/internal/upgrade/AssetDisplayPageServiceUpgrade.java
@@ -16,11 +16,14 @@ package com.liferay.asset.display.page.internal.upgrade;
 
 import com.liferay.asset.display.page.internal.upgrade.v1_0_0.UpgradeAssetDisplayPage;
 import com.liferay.asset.display.page.internal.upgrade.v2_0_0.util.AssetDisplayPageEntryTable;
+import com.liferay.journal.service.JournalArticleLocalService;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.upgrade.BaseUpgradeSQLServerDatetime;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author José Ángel Jiménez
@@ -32,12 +35,20 @@ public class AssetDisplayPageServiceUpgrade implements UpgradeStepRegistrator {
 	public void register(Registry registry) {
 		registry.register("0.0.1", "1.0.0", new DummyUpgradeStep());
 
-		registry.register("1.0.0", "1.1.0", new UpgradeAssetDisplayPage());
+		registry.register(
+			"1.0.0", "1.1.0",
+			new UpgradeAssetDisplayPage(_classNameLocalService));
 
 		registry.register(
 			"1.1.0", "2.0.0",
 			new BaseUpgradeSQLServerDatetime(
 				new Class<?>[] {AssetDisplayPageEntryTable.class}));
 	}
+
+	@Reference
+	private ClassNameLocalService _classNameLocalService;
+
+	@Reference
+	private JournalArticleLocalService _journalArticleLocalService;
 
 }

--- a/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/internal/upgrade/AssetDisplayPageServiceUpgrade.java
+++ b/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/internal/upgrade/AssetDisplayPageServiceUpgrade.java
@@ -14,8 +14,10 @@
 
 package com.liferay.asset.display.page.internal.upgrade;
 
+import com.liferay.asset.display.page.internal.upgrade.v1_0_0.UpgradeAssetDisplayPage;
 import com.liferay.asset.display.page.internal.upgrade.v2_0_0.util.AssetDisplayPageEntryTable;
 import com.liferay.portal.kernel.upgrade.BaseUpgradeSQLServerDatetime;
+import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import org.osgi.service.component.annotations.Component;
@@ -28,8 +30,12 @@ public class AssetDisplayPageServiceUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
+		registry.register("0.0.1", "1.0.0", new DummyUpgradeStep());
+
+		registry.register("1.0.0", "1.1.0", new UpgradeAssetDisplayPage());
+
 		registry.register(
-			"1.0.0", "2.0.0",
+			"1.1.0", "2.0.0",
 			new BaseUpgradeSQLServerDatetime(
 				new Class<?>[] {AssetDisplayPageEntryTable.class}));
 	}

--- a/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/internal/upgrade/v1_0_0/UpgradeAssetDisplayPage.java
+++ b/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/internal/upgrade/v1_0_0/UpgradeAssetDisplayPage.java
@@ -14,20 +14,89 @@
 
 package com.liferay.asset.display.page.internal.upgrade.v1_0_0;
 
+import com.liferay.asset.display.page.constants.AssetDisplayPageConstants;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.LoggingTimer;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
+
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
 
 /**
  * @author Vendel Toreki
  */
 public class UpgradeAssetDisplayPage extends UpgradeProcess {
 
-	public UpgradeAssetDisplayPage() {
+	public UpgradeAssetDisplayPage(
+		ClassNameLocalService classNameLocalService) {
+
+		_classNameLocalService = classNameLocalService;
 	}
 
 	@Override
 	protected void doUpgrade() throws Exception {
 		upgradeSchema();
+
+		upgradeAssetDisplayPageEntry();
+	}
+
+	protected void upgradeAssetDisplayPageEntry() throws Exception {
+		StringBuilder sb = new StringBuilder(8);
+
+		sb.append("select groupId, companyId, userId, userName, createDate, ");
+		sb.append("resourcePrimKey from JournalArticle where ");
+		sb.append("JournalArticle.layoutUuid is not null and ");
+		sb.append("JournalArticle.layoutUuid != '' and not exists ( ");
+		sb.append("select 1 from AssetDisplayPageEntry where ");
+		sb.append("AssetDisplayPageEntry.classNameId = ? ");
+		sb.append("and AssetDisplayPageEntry.classPK = ");
+		sb.append("JournalArticle.resourcePrimKey )");
+
+		long journalArticleClassNameId = _classNameLocalService.getClassNameId(
+			JournalArticle.class);
+
+		try (LoggingTimer loggingTimer = new LoggingTimer();
+			PreparedStatement ps1 = connection.prepareStatement(sb.toString());
+			PreparedStatement ps2 =
+				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+					connection, _createInsertSql());) {
+
+			ps1.setLong(1, journalArticleClassNameId);
+
+			try (ResultSet rs = ps1.executeQuery()) {
+				while (rs.next()) {
+					long groupId = rs.getLong("groupId");
+					long companyId = rs.getLong("companyId");
+					long userId = rs.getLong("userId");
+					String userName = rs.getString("userName");
+					Timestamp createDate = rs.getTimestamp("createDate");
+					long resourcePrimKey = rs.getLong("resourcePrimKey");
+
+					ps2.setString(1, PortalUUIDUtil.generate());
+					ps2.setLong(2, increment());
+					ps2.setLong(3, groupId);
+					ps2.setLong(4, companyId);
+					ps2.setLong(5, userId);
+					ps2.setString(6, userName);
+					ps2.setDate(7, new Date(createDate.getTime()));
+					ps2.setDate(8, new Date(createDate.getTime()));
+					ps2.setLong(9, journalArticleClassNameId);
+					ps2.setLong(10, resourcePrimKey);
+					ps2.setLong(11, 0);
+					ps2.setInt(12, AssetDisplayPageConstants.TYPE_SPECIFIC);
+
+					ps2.addBatch();
+				}
+
+				ps2.executeBatch();
+			}
+		}
 	}
 
 	protected void upgradeSchema() throws Exception {
@@ -37,5 +106,20 @@ public class UpgradeAssetDisplayPage extends UpgradeProcess {
 
 		runSQLTemplateString(template, false, false);
 	}
+
+	private String _createInsertSql() {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("insert into AssetDisplayPageEntry (uuid_, ");
+		sb.append("assetDisplayPageEntryId, groupId, companyId, userId, ");
+		sb.append("userName, createDate, modifiedDate, ");
+		sb.append("classNameId, classPK, layoutPageTemplateEntryId, ");
+		sb.append("type_) values (?, ?, ?, ?, ?, ?, ?, ");
+		sb.append("?, ?, ?, ?, ?)");
+
+		return sb.toString();
+	}
+
+	private final ClassNameLocalService _classNameLocalService;
 
 }

--- a/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/internal/upgrade/v1_0_0/UpgradeAssetDisplayPage.java
+++ b/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/internal/upgrade/v1_0_0/UpgradeAssetDisplayPage.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.asset.display.page.internal.upgrade.v1_0_0;
+
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.StringUtil;
+
+/**
+ * @author Vendel Toreki
+ */
+public class UpgradeAssetDisplayPage extends UpgradeProcess {
+
+	public UpgradeAssetDisplayPage() {
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		upgradeSchema();
+	}
+
+	protected void upgradeSchema() throws Exception {
+		String template = StringUtil.read(
+			UpgradeAssetDisplayPage.class.getResourceAsStream(
+				"dependencies/update.sql"));
+
+		runSQLTemplateString(template, false, false);
+	}
+
+}

--- a/modules/apps/asset/asset-display-page-service/src/main/resources/com/liferay/asset/display/page/internal/upgrade/v1_0_0/dependencies/update.sql
+++ b/modules/apps/asset/asset-display-page-service/src/main/resources/com/liferay/asset/display/page/internal/upgrade/v1_0_0/dependencies/update.sql
@@ -1,0 +1,22 @@
+create table AssetDisplayPageEntry (
+	uuid_ VARCHAR(75) null,
+	assetDisplayPageEntryId LONG not null primary key,
+	groupId LONG,
+	companyId LONG,
+	userId LONG,
+	userName VARCHAR(75) null,
+	createDate DATE null,
+	modifiedDate DATE null,
+	classNameId LONG,
+	classPK LONG,
+	layoutPageTemplateEntryId LONG,
+	type_ INTEGER
+);
+
+create index IX_31FA120C on AssetDisplayPageEntry (classNameId, classPK);
+create unique index IX_A21FC9A8 on AssetDisplayPageEntry (groupId, classNameId, classPK);
+create index IX_BFB8A913 on AssetDisplayPageEntry (layoutPageTemplateEntryId);
+create index IX_1DA6952B on AssetDisplayPageEntry (uuid_[$COLUMN_LENGTH:75$], companyId);
+create unique index IX_DB986A6D on AssetDisplayPageEntry (uuid_[$COLUMN_LENGTH:75$], groupId);
+
+COMMIT_TRANSACTION;

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/EditArticleDisplayPageDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/EditArticleDisplayPageDisplayContext.java
@@ -157,9 +157,18 @@ public class EditArticleDisplayPageDisplayContext {
 			getAssetDisplayPageEntry();
 
 		if (assetDisplayPageEntry == null) {
-			_displayPageType = AssetDisplayPageConstants.TYPE_NONE;
+			JournalArticle article = getArticle();
 
-			return _displayPageType;
+			if (Validator.isNotNull(article.getLayoutUuid())) {
+				_displayPageType = AssetDisplayPageConstants.TYPE_SPECIFIC;
+
+				return _displayPageType;
+			}
+			else {
+				_displayPageType = AssetDisplayPageConstants.TYPE_NONE;
+
+				return _displayPageType;
+			}
 		}
 
 		_displayPageType = assetDisplayPageEntry.getType();

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_1_x/UpgradeModules.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_1_x/UpgradeModules.java
@@ -32,6 +32,7 @@ public class UpgradeModules
 
 	private static final String[] _BUNDLE_SYMBOLIC_NAMES = {
 		"com.liferay.asset.category.property.service",
+		"com.liferay.asset.display.page.service",
 		"com.liferay.asset.tag.stats.service", "com.liferay.blogs.service",
 		"com.liferay.document.library.content.service",
 		"com.liferay.document.library.file.rank.service",


### PR DESCRIPTION
Hi @jkappler ,

I created a fix that consists of 3 parts:

1. https://github.com/jkappler/liferay-portal/commit/cbf80ab7ec1d211e949cba8581f248b925994b1b fixes the upgrade process that was created by LPS-86288 but was not running correctly.
1. https://github.com/jkappler/liferay-portal/commit/54c52f05251c775f113d7d1bbf91ed138ba795cd adds an upgrade step that populates `AssetDisplayPageEntry` table. The dependency on `journal-api` was added to make sure this upgrade step runs after the `JournalArticle` update, mainly because the className of `JournalArticle` changes during its upgrade. If `AssetDisplayPageEntry` runs before, the classNameIds won't match.
1. https://github.com/jkappler/liferay-portal/commit/059ccac4599020a53d57c20dd829badba18a67b7 This makes sure that even when the `AssetDisplayPageEntry` records are not created, the Web Content editor will still show the Display Page property correctly (since the display layout is still stored in `JournalArticle.layoutUuid` column).

Please review my changes.

Thanks,
Vendel