### PR TITLE
LPS-89648

### DIFF
--- a/portal-kernel/src/com/liferay/asset/kernel/model/BaseAssetRendererFactory.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/BaseAssetRendererFactory.java
@@ -222,13 +222,17 @@ public abstract class BaseAssetRendererFactory<T>
 		String value = LanguageUtil.get(locale, key, null);
 
 		if (value == null) {
-			PortletBag portletBag = PortletBagPool.get(getPortletId());
+			try {
+				PortletBag portletBag = PortletBagPool.get(getPortletId());
 
-			ResourceBundle resourceBundle = portletBag.getResourceBundle(
-				locale);
+				ResourceBundle resourceBundle = portletBag.getResourceBundle(
+					locale);
 
-			if (resourceBundle != null) {
-				value = ResourceBundleUtil.getString(resourceBundle, key);
+				if (resourceBundle != null) {
+					value = ResourceBundleUtil.getString(resourceBundle, key);
+				}
+			}
+			catch (NullPointerException npe) {
 			}
 		}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-89648

In order to test this issue in master, you'll need to create a new AssetRenderer class and implement it without a portletId.  You can see my changes are safe, because the default action if we cannot retrieve the resourceBundle from the portlet bag is to simply return the className.

Please let me know if you have any questions.  Thanks!