### PR TITLE
[TECHNICAL-SUPPORT] LPS-100472 Hide display page template selection for global web contents

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/ui/JournalDisplayPageFormNavigatorEntry.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/ui/JournalDisplayPageFormNavigatorEntry.java
@@ -15,9 +15,18 @@
 package com.liferay.journal.web.internal.servlet.taglib.ui;
 
 import com.liferay.item.selector.ItemSelectorView;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.servlet.taglib.ui.FormNavigatorEntry;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
 
 import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -35,6 +44,33 @@ public class JournalDisplayPageFormNavigatorEntry
 	@Override
 	public String getKey() {
 		return "display-page-template";
+	}
+
+	@Override
+	public boolean isVisible(User user, JournalArticle article) {
+		Group group = null;
+
+		if ((article != null) && (article.getId() > 0)) {
+			group = _groupLocalService.fetchGroup(article.getGroupId());
+		}
+		else {
+			ServiceContext serviceContext =
+				ServiceContextThreadLocal.getServiceContext();
+
+			HttpServletRequest httpServletRequest = serviceContext.getRequest();
+
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)httpServletRequest.getAttribute(
+					WebKeys.THEME_DISPLAY);
+
+			group = themeDisplay.getScopeGroup();
+		}
+
+		if ((group != null) && group.isCompany()) {
+			return false;
+		}
+
+		return true;
 	}
 
 	@Reference(target = "(view=private)", unbind = "-")
@@ -59,5 +95,8 @@ public class JournalDisplayPageFormNavigatorEntry
 	protected String getJspPath() {
 		return "/article/display_page.jsp";
 	}
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 }


### PR DESCRIPTION
Hi @jkappler ,

When editing a Global scoped web content that is displayed in a site's scope, the editor allowed users to select Display Pages from the site's scope. However, this should not be possible:
1. Global scope can't have any display pages (either Display Page Template or Pages with default Asset Publisher)
2. The display page of the web content should be in its own site

Therefore, global web contents are not allowed to have display pages.
This is not a problem for non-global contents, since they are always edited in their own scope. The reason why global contents are different is described in [this LPS comment](https://issues.liferay.com/browse/LPS-100472?focusedCommentId=1950138&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1950138).

Please review my changes.

Thanks,
Vendel