### PR TITLE
[TS] LPS-105307

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherHelperImpl.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherHelperImpl.java
@@ -39,6 +39,8 @@ import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
@@ -687,6 +689,17 @@ public class AssetPublisherHelperImpl implements AssetPublisherHelper {
 			Group childGroup = _groupLocalService.getGroup(childGroupId);
 
 			if (!childGroup.hasAncestor(siteGroupId)) {
+				if (_log.isWarnEnabled()) {
+					StringBundler sb = new StringBundler(4);
+
+					sb.append("Child group with id ");
+					sb.append(childGroupId);
+					sb.append(" does not have a parent site with id ");
+					sb.append(siteGroupId);
+
+					_log.warn(sb.toString());
+				}
+
 				throw new PrincipalException();
 			}
 
@@ -744,12 +757,29 @@ public class AssetPublisherHelperImpl implements AssetPublisherHelper {
 			Group parentGroup = _groupLocalService.getGroup(parentGroupId);
 
 			if (!SitesUtil.isContentSharingWithChildrenEnabled(parentGroup)) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						"Parent group " + parentGroupId +
+							"does not have content sharing enabled.");
+				}
+
 				throw new PrincipalException();
 			}
 
 			Group group = _groupLocalService.getGroup(siteGroupId);
 
 			if (!group.hasAncestor(parentGroupId)) {
+				if (_log.isWarnEnabled()) {
+					StringBundler sb = new StringBundler(4);
+
+					sb.append("Group with id ");
+					sb.append(parentGroupId);
+					sb.append(" is not the parent group of site with id ");
+					sb.append(siteGroupId);
+
+					_log.warn(sb.toString());
+				}
+
 				throw new PrincipalException();
 			}
 
@@ -1315,6 +1345,9 @@ public class AssetPublisherHelperImpl implements AssetPublisherHelper {
 
 		assetEntryQuery.setNotAnyTagIds(notAnyAssetTagIds);
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		AssetPublisherHelperImpl.class);
 
 	@Reference
 	private AssetCategoryLocalService _assetCategoryLocalService;

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherHelperImpl.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherHelperImpl.java
@@ -699,8 +699,6 @@ public class AssetPublisherHelperImpl implements AssetPublisherHelper {
 
 					_log.warn(sb.toString());
 				}
-
-				throw new PrincipalException();
 			}
 
 			return childGroupId;
@@ -779,8 +777,6 @@ public class AssetPublisherHelperImpl implements AssetPublisherHelper {
 
 					_log.warn(sb.toString());
 				}
-
-				throw new PrincipalException();
 			}
 
 			return parentGroupId;

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherHelperImpl.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherHelperImpl.java
@@ -688,17 +688,15 @@ public class AssetPublisherHelperImpl implements AssetPublisherHelper {
 
 			Group childGroup = _groupLocalService.getGroup(childGroupId);
 
-			if (!childGroup.hasAncestor(siteGroupId)) {
-				if (_log.isWarnEnabled()) {
-					StringBundler sb = new StringBundler(4);
+			if (!childGroup.hasAncestor(siteGroupId) && _log.isWarnEnabled()) {
+				StringBundler sb = new StringBundler(4);
 
-					sb.append("Child group with id ");
-					sb.append(childGroupId);
-					sb.append(" does not have a parent site with id ");
-					sb.append(siteGroupId);
+				sb.append("Child group with id ");
+				sb.append(childGroupId);
+				sb.append(" does not have a parent site with id ");
+				sb.append(siteGroupId);
 
-					_log.warn(sb.toString());
-				}
+				_log.warn(sb.toString());
 			}
 
 			return childGroupId;
@@ -766,17 +764,15 @@ public class AssetPublisherHelperImpl implements AssetPublisherHelper {
 
 			Group group = _groupLocalService.getGroup(siteGroupId);
 
-			if (!group.hasAncestor(parentGroupId)) {
-				if (_log.isWarnEnabled()) {
-					StringBundler sb = new StringBundler(4);
+			if (!group.hasAncestor(parentGroupId) && _log.isWarnEnabled()) {
+				StringBundler sb = new StringBundler(4);
 
-					sb.append("Group with id ");
-					sb.append(parentGroupId);
-					sb.append(" is not the parent group of site with id ");
-					sb.append(siteGroupId);
+				sb.append("Group with id ");
+				sb.append(parentGroupId);
+				sb.append(" is not the parent group of site with id ");
+				sb.append(siteGroupId);
 
-					_log.warn(sb.toString());
-				}
+				_log.warn(sb.toString());
 			}
 
 			return parentGroupId;


### PR DESCRIPTION
From @wanderlast:

https://issues.liferay.com/browse/LPS-105307
https://issues.liferay.com/browse/PTR-1427

> This issue relates to behavior that occurs when a parent-child site relationship is broken and an AP exists on the parent site that has the child site as its scope. This leads to issues in AssetPublisherHelperImpl, specifically in getGroupIdFromScopeId since the site that is no longer officially a child site is still identified as one in the portlet preferences. In PTR-1427, Daniel Cuoso stated the following:
> 
> > Regarding the code that you refer to, I would like to note that LPS-39630 introduced these exceptions for child and parent sites. With LPS-89942, the export/import of AssetPublisher preferences was changed to throw exceptions aborting the process instead of just warning about them letting it go on.
> > 
> > Knowing this and taking a look at the code, the PrincipalException should not be thrown (or if thrown, properly caught) when an export or a publish is in progress, warning about the fact that the groupId could not be calculated based on the given scopeId.
> 
> Therefore the fix does the following:
> We no longer throw an exception for this specific issue and instead run a warn message. Exports therefore are no longer stopped for this issue despite the issue. When importing, issues are fixed since the scope actually corrects itself and therefore no warns occur. 
> 
> The warn is fairly noisy. It happens twice and happens not only when exporting but also when interacting with the page that the AP is on. I don't believe this is a bad thing necessarily since I can't see any purposeful case of a client intentionally keeping their AP with an incorrect scope, but it is something that may need to be reconsidered.