### PR TITLE
[TECHNICAL SUPPORT] LPS-106070

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
@@ -22,6 +22,7 @@ import com.liferay.exportimport.kernel.lar.ExportImportHelper;
 import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
 import com.liferay.exportimport.kernel.lar.ExportImportProcessCallbackRegistry;
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
+import com.liferay.exportimport.kernel.lar.ManifestSummary;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.PortletDataContextFactory;
 import com.liferay.exportimport.kernel.lar.PortletDataException;
@@ -1531,11 +1532,17 @@ public class LayoutStagedModelDataHandler
 
 			Element portletDataElement = portletElement.element("portlet-data");
 
+			ManifestSummary manifestSummary =
+				portletDataContext.getManifestSummary();
+
+			if (layout.isTypeAssetDisplay()) {
+				manifestSummary = null;
+			}
+
 			Map<String, Boolean> importPortletControlsMap =
 				_exportImportHelper.getImportPortletControlsMap(
 					portletDataContext.getCompanyId(), portletId, parameterMap,
-					portletDataElement,
-					portletDataContext.getManifestSummary());
+					portletDataElement, manifestSummary);
 
 			if (layout != null) {
 				portletPreferencesGroupId = layout.getGroupId();

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
@@ -1528,8 +1528,6 @@ public class LayoutStagedModelDataHandler
 			_exportImportHelper.setPortletScope(
 				portletDataContext, portletElement);
 
-			long portletPreferencesGroupId = portletDataContext.getGroupId();
-
 			Element portletDataElement = portletElement.element("portlet-data");
 
 			ManifestSummary manifestSummary =
@@ -1544,9 +1542,7 @@ public class LayoutStagedModelDataHandler
 					portletDataContext.getCompanyId(), portletId, parameterMap,
 					portletDataElement, manifestSummary);
 
-			if (layout != null) {
-				portletPreferencesGroupId = layout.getGroupId();
-			}
+			long portletPreferencesGroupId = layout.getGroupId();
 
 			try {
 				_exportImportLifecycleManager.fireExportImportLifecycleEvent(

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
@@ -373,7 +373,7 @@ public class LayoutStagedModelDataHandler
 		}
 		else if (Objects.equals(
 					layout.getType(), LayoutConstants.TYPE_PORTLET) ||
-				 layout.isTypeContent()) {
+				 layout.isTypeContent() || layout.isTypeAssetDisplay()) {
 
 			exportLayoutPortlets(portletDataContext, layout, layoutElement);
 		}
@@ -850,7 +850,7 @@ public class LayoutStagedModelDataHandler
 
 		if ((Objects.equals(layout.getType(), LayoutConstants.TYPE_PORTLET) &&
 			 Validator.isNotNull(layout.getTypeSettings())) ||
-			layout.isTypeContent()) {
+			layout.isTypeContent() || layout.isTypeAssetDisplay()) {
 
 			importLayoutPortlets(
 				portletDataContext, importedLayout, layoutElement);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-106070

AssetDisplay layouts are not added to manifest.xml, so in order to import portlet configuration we should force it, ignoring manifestSummary (see https://github.com/jkappler/liferay-portal/pull/657/commits/892be990fa724212aa00b0bd6a1b11e4ac3f04a2)

Root cause of this:

- `importPortletControlsMap` is calculated using "portlet-configuration" attribute of portlet entry inside Layout element from **manifest.xml**
- But in case of AssetDisplay layouts, the Layout entry is added to **/group/35632/portlet/com_liferay_layout_admin_web_portlet_GroupPagesPortlet/0/portlet-data.xml** file because it is not a real Layout.

Other solutions to this issue whould be:

- **Option 1:** At export time, change export code in order to include Layout entry at manifest.xml level
- **Option 2:** At import time, change import code in order to read Layout entry from portlet-data.xml file.

Nevetheless, I think both solutions are more difficult to implement than just ignoring manifestSummary variable setting it to null.