### PR TITLE
[TS] LPS-108113 Don't export AssetDisplayPageEntry object the second time _exportAssetDisplayPage code is executed to avoid a loop that causes a stackoverflow

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -1342,7 +1342,9 @@ public class JournalArticleStagedModelDataHandler
 				_portal.getClassNameId(JournalArticle.class),
 				article.getResourcePrimKey());
 
-		if (assetDisplayPageEntry != null) {
+		if ((assetDisplayPageEntry != null) &&
+			(assetDisplayPageEntry.getPlid() != portletDataContext.getPlid())) {
+
 			StagedModelDataHandlerUtil.exportReferenceStagedModel(
 				portletDataContext, article, assetDisplayPageEntry,
 				PortletDataContext.REFERENCE_TYPE_DEPENDENCY);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-108113

@dacousalr, thank you for your idea, it works fine!!