### PR TITLE
Apply new URL format in JournalArticleAssetRenderer

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/model/JournalArticleAssetRenderer.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/model/JournalArticleAssetRenderer.java
@@ -34,7 +34,6 @@ import com.liferay.journal.web.internal.asset.JournalArticleDDMFormValuesReader;
 import com.liferay.journal.web.internal.security.permission.resource.JournalArticlePermission;
 import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -58,6 +57,7 @@ import com.liferay.portal.kernel.trash.TrashRenderer;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -430,8 +430,8 @@ public class JournalArticleAssetRenderer
 
 			if (Validator.isNotNull(friendlyURL)) {
 				if (!_article.isApproved()) {
-					friendlyURL =
-						friendlyURL + StringPool.SLASH + _article.getId();
+					friendlyURL = HttpUtil.addParameter(
+						friendlyURL, "version", _article.getId());
 				}
 
 				return friendlyURL;
@@ -443,18 +443,20 @@ public class JournalArticleAssetRenderer
 				group.getGroupId(), layout.isPrivateLayout()),
 			themeDisplay);
 
-		StringBundler sb = new StringBundler(5);
+		StringBundler sb = new StringBundler(3);
 
 		sb.append(groupFriendlyURL);
 		sb.append(JournalArticleConstants.CANONICAL_URL_SEPARATOR);
 		sb.append(_article.getUrlTitle(themeDisplay.getLocale()));
 
+		String friendlyURL = sb.toString();
+
 		if (!_article.isApproved()) {
-			sb.append(StringPool.SLASH);
-			sb.append(_article.getId());
+			friendlyURL = HttpUtil.addParameter(
+				friendlyURL, "version", _article.getId());
 		}
 
-		return PortalUtil.addPreservedParameters(themeDisplay, sb.toString());
+		return PortalUtil.addPreservedParameters(themeDisplay, friendlyURL);
 	}
 
 	@Override


### PR DESCRIPTION
Hi @jkappler ,
Thanks for your help on LPS-128329, removing the id of the article from the URL path didn't cross our minds but it surely brought a smile on my face when I saw it.

I'd like to extend it with this change to the AssetRenderer.
Although I can't test this due to Windows machines having issues with building at the moment

Balázs