### PR TITLE
LRAC-9857 Allow developers to flag no tracking attribute in the journal Taglib so AC will not track this taglib OOTB

### DIFF
--- a/modules/apps/journal/journal-taglib/src/main/resources/META-INF/resources/journal_article/page.jsp
+++ b/modules/apps/journal/journal-taglib/src/main/resources/META-INF/resources/journal_article/page.jsp
@@ -31,7 +31,7 @@ String wrapperCssClass = (String)request.getAttribute("liferay-journal:journal-a
 		</div>
 	</c:when>
 	<c:otherwise>
-		<div class="journal-content-article <%= Validator.isNotNull(wrapperCssClass) ? wrapperCssClass : StringPool.BLANK %>" data-analytics-asset-id="<%= articleDisplay.getArticleId() %>" data-analytics-asset-title="<%= HtmlUtil.escapeAttribute(articleDisplay.getTitle()) %>" data-analytics-asset-type="web-content" <%= dataAnalyticsTrackEnabled ? "" : "data-analytics-no-track" %>>
+		<div class="journal-content-article <%= Validator.isNotNull(wrapperCssClass) ? wrapperCssClass : StringPool.BLANK %>" <%= dataAnalyticsTrackEnabled ? String.format("data-analytics-asset-id=\"%s\" data-analytics-asset-title=\"%s\" data-analytics-asset-type=\"web-content\"", articleDisplay.getArticleId(), HtmlUtil.escapeAttribute(articleDisplay.getTitle())) : "" %>>
 			<c:if test='<%= GetterUtil.getBoolean((String)request.getAttribute("liferay-journal:journal-article:showTitle")) %>'>
 				<%= HtmlUtil.escape(articleDisplay.getTitle()) %>
 			</c:if>


### PR DESCRIPTION
hi @jkappler, I saw you did some activity on https://issues.liferay.com/browse/LPS-142963 and I thought I could send this pull request for your review.

This commit was reverted because of the two cases described on this ticket. However, I could not reproduce the first case on master HEAD with my commit included. Also, I could not understand how my commit could cause the following error either? Let me know what you think.

`2021-11-23 23:12:41.724 ERROR [http-nio-8080-exec-5][FragmentRendererControllerImpl:126] Unable to render content of fragment entry 0:com.liferay.journal.model.impl.JournalArticleImpl cannot be cast to com.liferay.asset.kernel.model.AssetEntry`

For the second case, we might need to update the expected result on the POSHI test because of the changes.

Thank you,