### PR TITLE
LPS-158561 New vhost properties

### DIFF
--- a/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
+++ b/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
@@ -737,9 +737,17 @@ public class MainServlet extends HttpServlet {
 		}
 
 		if (StartupHelperUtil.isDBNew()) {
+			String companyDefaultVirtualHostName = GetterUtil.getString(
+				PropsValues.COMPANY_DEFAULT_VIRTUAL_HOST_NAME, "localhost");
+
+			String companyDefaultVirtualHostMailDomain = GetterUtil.getString(
+				PropsValues.COMPANY_DEFAULT_VIRTUAL_HOST_MAIL_DOMAIN,
+				PropsValues.COMPANY_DEFAULT_WEB_ID);
+
 			CompanyLocalServiceUtil.addCompany(
-				null, PropsValues.COMPANY_DEFAULT_WEB_ID, "localhost",
-				PropsValues.COMPANY_DEFAULT_WEB_ID, false, 0, true);
+				null, PropsValues.COMPANY_DEFAULT_WEB_ID,
+				companyDefaultVirtualHostName,
+				companyDefaultVirtualHostMailDomain, false, 0, true);
 		}
 
 		ServletContext servletContext = getServletContext();

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -369,6 +369,12 @@ public class PropsValues {
 	public static String COMPANY_DEFAULT_TIME_ZONE = PropsUtil.get(
 		PropsKeys.COMPANY_DEFAULT_TIME_ZONE);
 
+	public static String COMPANY_DEFAULT_VIRTUAL_HOST_MAIL_DOMAIN =
+		PropsUtil.get(PropsKeys.COMPANY_DEFAULT_VIRTUAL_HOST_MAIL_DOMAIN);
+
+	public static String COMPANY_DEFAULT_VIRTUAL_HOST_NAME = PropsUtil.get(
+		PropsKeys.COMPANY_DEFAULT_VIRTUAL_HOST_NAME);
+
 	public static String COMPANY_DEFAULT_WEB_ID = PropsUtil.get(
 		PropsKeys.COMPANY_DEFAULT_WEB_ID);
 

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -1819,6 +1819,20 @@
     company.default.web.id=liferay.com
 
     #
+    # This sets the default virtual host name for the company.
+    #
+    # Env: LIFERAY_COMPANY_PERIOD_DEFAULT_PERIOD_VIRTUAL_PERIOD_HOST_PERIOD_NAME
+    #
+    #company.default.virtual.host.name=localhost
+
+    #
+    # This sets the default virtual host mail domain for the company.
+    #
+    # Env: LIFERAY_COMPANY_PERIOD_DEFAULT_PERIOD_VIRTUAL_PERIOD_HOST_PERIOD_MAIL_PERIOD_DOMAIN
+    #
+    #company.default.virtual.host.mail.domain=liferay.com
+
+    #
     # This sets the default home URL of the portal.
     #
     # Env: LIFERAY_COMPANY_PERIOD_DEFAULT_PERIOD_HOME_PERIOD_URL

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -439,6 +439,12 @@ public interface PropsKeys {
 	public static final String COMPANY_DEFAULT_TIME_ZONE =
 		"company.default.time.zone";
 
+	public static final String COMPANY_DEFAULT_VIRTUAL_HOST_MAIL_DOMAIN =
+		"company.default.virtual.host.mail.domain";
+
+	public static final String COMPANY_DEFAULT_VIRTUAL_HOST_NAME =
+		"company.default.virtual.host.name";
+
 	public static final String COMPANY_DEFAULT_WEB_ID =
 		"company.default.web.id";
 


### PR DESCRIPTION
- LPS-158561 Adds two new properties, one for the default virtual host name of a company, the other one for the mail domain. The values are determined based on current values. The order comes from the vhost table
- LPS-158561 Adds props values and keys for the new properties
- LPS-158561 Use the new properties. To maintain the current behaviour we always default to the current implementation, that is, localhost for host name, and web ID for mail domain
