### PR TITLE
LPS-162084 Change rolename for open.id.connect.user.info.processor.impl.regular.role in liferay online properties

### DIFF
--- a/portal-impl/src/portal-liferay-online-config.properties
+++ b/portal-impl/src/portal-liferay-online-config.properties
@@ -15,7 +15,7 @@ web.server.forwarded.protocol.enabled=true
 json.servlet.hosts.allowed=N/A
 
 open.id.connect.user.info.processor.impl.issuer=https://login.liferay.com
-open.id.connect.user.info.processor.impl.regular.role=LXC Admin
+open.id.connect.user.info.processor.impl.regular.role=Administrator
 
 configuration.override.com.liferay.dynamic.data.mapping.data.provider.configuration.DDMDataProviderConfiguration_accessLocalNetwork=B"false"
 configuration.override.com.liferay.dynamic.data.mapping.form.web.internal.configuration.DDMFormWebConfiguration_guestUploadMaximumFileSize=I"10"


### PR DESCRIPTION
## Motivation

Only the selected group of users are able to login with OKTA provider and all of them should be able to manage everything on the Admin instance.