### PR TITLE
WIP

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/JournalConfigurationAction.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/JournalConfigurationAction.java
@@ -23,6 +23,7 @@ import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
 import javax.portlet.PortletConfig;
 import javax.portlet.PortletRequest;
+import javax.portlet.WindowState;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -47,6 +48,11 @@ public class JournalConfigurationAction
 	@Override
 	public String getJspPath(HttpServletRequest httpServletRequest) {
 		return "/configuration.jsp";
+	}
+
+	@Override
+	public WindowState getWindowsState() {
+		return WindowState.MAXIMIZED;
 	}
 
 	@Override

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/configuration/icon/BaseConfigurationPortletConfigurationIcon.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/configuration/icon/BaseConfigurationPortletConfigurationIcon.java
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portlet.configuration.web.internal.portlet.configuration.icon;
+
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.portlet.configuration.icon.BaseJSPPortletConfigurationIcon;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+
+import java.util.Map;
+
+import javax.portlet.PortletRequest;
+
+/**
+ * @author Jürgen Kappler
+ */
+public abstract class BaseConfigurationPortletConfigurationIcon
+	extends BaseJSPPortletConfigurationIcon {
+
+	@Override
+	public Map<String, Object> getContext(PortletRequest portletRequest) {
+		return HashMapBuilder.<String, Object>put(
+			"action", getNamespace(portletRequest) + "configuration"
+		).put(
+			"globalAction", true
+		).build();
+	}
+
+	@Override
+	public String getCssClass() {
+		return "portlet-configuration portlet-configuration-icon";
+	}
+
+	@Override
+	public String getIconCssClass() {
+		return "cog";
+	}
+
+	@Override
+	public String getMessage(PortletRequest portletRequest) {
+		return LanguageUtil.get(getLocale(portletRequest), "configuration");
+	}
+
+	@Override
+	public double getWeight() {
+		return 14.0;
+	}
+
+	@Override
+	public boolean isShowInEditMode(PortletRequest portletRequest) {
+		return true;
+	}
+
+}

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/configuration/icon/BasicConfigurationPortletConfigurationIcon.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/configuration/icon/BasicConfigurationPortletConfigurationIcon.java
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portlet.configuration.web.internal.portlet.configuration.icon;
+
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.portlet.LiferayWindowState;
+import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
+import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
+import com.liferay.portal.kernel.theme.PortletDisplay;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import javax.portlet.PortletRequest;
+import javax.portlet.PortletResponse;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Eudaldo Alonso
+ */
+@Component(service = PortletConfigurationIcon.class)
+public class BasicConfigurationPortletConfigurationIcon
+	extends BasePortletConfigurationIcon {
+
+	@Override
+	public String getURL(
+		PortletRequest portletRequest, PortletResponse portletResponse) {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+		return portletDisplay.getURLConfiguration();
+	}
+
+	@Override
+	public boolean isShow(PortletRequest portletRequest) {
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		Layout layout = themeDisplay.getLayout();
+
+		if (layout.isEmbeddedPersonalApplication()) {
+			return false;
+		}
+
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+		if (portletDisplay.getURLConfigurationWindowState() ==
+				LiferayWindowState.POP_UP) {
+
+			return false;
+		}
+
+		return portletDisplay.isShowConfigurationIcon();
+	}
+
+}

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/configuration/icon/JsConfigurationPortletConfigurationIcon.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/configuration/icon/JsConfigurationPortletConfigurationIcon.java
@@ -5,16 +5,12 @@
 
 package com.liferay.portlet.configuration.web.internal.portlet.configuration.icon;
 
-import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.portlet.configuration.icon.BaseJSPPortletConfigurationIcon;
+import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.WebKeys;
-
-import java.util.Map;
 
 import javax.portlet.PortletRequest;
 
@@ -27,41 +23,12 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eudaldo Alonso
  */
 @Component(service = PortletConfigurationIcon.class)
-public class ConfigurationPortletConfigurationIcon
-	extends BaseJSPPortletConfigurationIcon {
-
-	@Override
-	public Map<String, Object> getContext(PortletRequest portletRequest) {
-		return HashMapBuilder.<String, Object>put(
-			"action", getNamespace(portletRequest) + "configuration"
-		).put(
-			"globalAction", true
-		).build();
-	}
-
-	@Override
-	public String getCssClass() {
-		return "portlet-configuration portlet-configuration-icon";
-	}
-
-	@Override
-	public String getIconCssClass() {
-		return "cog";
-	}
+public class JsConfigurationPortletConfigurationIcon
+	extends BaseConfigurationPortletConfigurationIcon {
 
 	@Override
 	public String getJspPath() {
 		return "/configuration/icon/configuration.jsp";
-	}
-
-	@Override
-	public String getMessage(PortletRequest portletRequest) {
-		return _language.get(getLocale(portletRequest), "configuration");
-	}
-
-	@Override
-	public double getWeight() {
-		return 14.0;
 	}
 
 	@Override
@@ -77,21 +44,19 @@ public class ConfigurationPortletConfigurationIcon
 
 		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
 
-		return portletDisplay.isShowConfigurationIcon();
-	}
+		if (portletDisplay.getURLConfigurationWindowState() !=
+				LiferayWindowState.POP_UP) {
 
-	@Override
-	public boolean isShowInEditMode(PortletRequest portletRequest) {
-		return true;
+			return false;
+		}
+
+		return portletDisplay.isShowConfigurationIcon();
 	}
 
 	@Override
 	protected ServletContext getServletContext() {
 		return _servletContext;
 	}
-
-	@Reference
-	private Language _language;
 
 	@Reference(
 		target = "(osgi.web.symbolicname=com.liferay.portlet.configuration.web)"

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 127.0.1
+Bundle-Version: 127.1.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/ConfigurationAction.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/ConfigurationAction.java
@@ -8,6 +8,7 @@ package com.liferay.portal.kernel.portlet;
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
 import javax.portlet.PortletConfig;
+import javax.portlet.WindowState;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -16,6 +17,10 @@ import javax.servlet.http.HttpServletResponse;
  * @author Brian Wing Shun Chan
  */
 public interface ConfigurationAction {
+
+	public default WindowState getWindowsState() {
+		return LiferayWindowState.POP_UP;
+	}
 
 	public void include(
 			PortletConfig portletConfig, HttpServletRequest httpServletRequest,

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/packageinfo
@@ -1,1 +1,1 @@
-version 27.0.0
+version 27.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/theme/PortletDisplay.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/theme/PortletDisplay.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
+import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIconMenu;
 import com.liferay.portal.kernel.portlet.toolbar.PortletToolbar;
 import com.liferay.portal.kernel.util.Constants;
@@ -28,6 +29,7 @@ import java.io.Serializable;
 import java.io.Writer;
 
 import javax.portlet.PortletPreferences;
+import javax.portlet.WindowState;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -115,6 +117,7 @@ public class PortletDisplay implements Cloneable, Serializable {
 		_urlClose = master.getURLClose();
 		_urlConfiguration = master.getURLConfiguration();
 		_urlConfigurationJS = master.getURLConfigurationJS();
+		_urlConfigurationWindowState = master.getURLConfigurationWindowState();
 		_urlEdit = master.getURLEdit();
 		_urlEditDefaults = master.getURLEditDefaults();
 		_urlEditGuest = master.getURLEditGuest();
@@ -185,6 +188,7 @@ public class PortletDisplay implements Cloneable, Serializable {
 		slave.setURLClose(_urlClose);
 		slave.setURLConfiguration(_urlConfiguration);
 		slave.setURLConfigurationJS(_urlConfigurationJS);
+		slave.setUrlConfigurationWindowState(_urlConfigurationWindowState);
 		slave.setURLEdit(_urlEdit);
 		slave.setURLEditDefaults(_urlEditDefaults);
 		slave.setURLEditGuest(_urlEditGuest);
@@ -304,6 +308,10 @@ public class PortletDisplay implements Cloneable, Serializable {
 
 	public String getURLConfigurationJS() {
 		return _urlConfigurationJS;
+	}
+
+	public WindowState getURLConfigurationWindowState() {
+		return _urlConfigurationWindowState;
 	}
 
 	public String getURLEdit() {
@@ -599,6 +607,7 @@ public class PortletDisplay implements Cloneable, Serializable {
 		_urlBack = StringPool.BLANK;
 		_urlClose = StringPool.BLANK;
 		_urlConfiguration = StringPool.BLANK;
+		_urlConfigurationWindowState = LiferayWindowState.POP_UP;
 		_urlEdit = StringPool.BLANK;
 		_urlEditDefaults = StringPool.BLANK;
 		_urlEditGuest = StringPool.BLANK;
@@ -865,6 +874,12 @@ public class PortletDisplay implements Cloneable, Serializable {
 		_urlConfigurationJS = urlConfigurationJS;
 	}
 
+	public void setUrlConfigurationWindowState(
+		WindowState urlConfigurationWindowState) {
+
+		_urlConfigurationWindowState = urlConfigurationWindowState;
+	}
+
 	public void setURLEdit(String urlEdit) {
 		_urlEdit = urlEdit;
 	}
@@ -983,6 +998,8 @@ public class PortletDisplay implements Cloneable, Serializable {
 	private String _urlClose = StringPool.BLANK;
 	private String _urlConfiguration = StringPool.BLANK;
 	private String _urlConfigurationJS = StringPool.BLANK;
+	private WindowState _urlConfigurationWindowState =
+		LiferayWindowState.POP_UP;
 	private String _urlEdit = StringPool.BLANK;
 	private String _urlEditDefaults = StringPool.BLANK;
 	private String _urlEditGuest = StringPool.BLANK;

--- a/portal-kernel/src/com/liferay/portal/kernel/theme/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/theme/packageinfo
@@ -1,1 +1,1 @@
-version 11.1.0
+version 11.2.0

--- a/portal-web/docroot/html/portal/init.jsp
+++ b/portal-web/docroot/html/portal/init.jsp
@@ -26,6 +26,7 @@ page import="com.liferay.portal.kernel.exception.UserLockoutException" %><%@
 page import="com.liferay.portal.kernel.exception.UserPasswordException" %><%@
 page import="com.liferay.portal.kernel.exception.UserReminderQueryException" %><%@
 page import="com.liferay.portal.kernel.license.util.LicenseManagerUtil" %><%@
+page import="com.liferay.portal.kernel.portlet.ConfigurationAction" %><%@
 page import="com.liferay.portal.kernel.portlet.PortletConfigurationLayoutUtil" %><%@
 page import="com.liferay.portal.kernel.service.LayoutLocalServiceUtil" %><%@
 page import="com.liferay.portal.kernel.servlet.HttpHeaders" %><%@

--- a/portal-web/docroot/html/portal/render_portlet.jsp
+++ b/portal-web/docroot/html/portal/render_portlet.jsp
@@ -12,6 +12,7 @@ String cmd = ParamUtil.getString(request, Constants.CMD);
 
 Portlet portlet = (Portlet)request.getAttribute(WebKeys.RENDER_PORTLET);
 
+ConfigurationAction configurationAction = portlet.getConfigurationActionInstance();
 String portletId = portlet.getPortletId();
 String rootPortletId = portlet.getRootPortletId();
 String instanceId = portlet.getInstanceId();
@@ -180,7 +181,7 @@ Layout curLayout = PortletConfigurationLayoutUtil.getLayout(themeDisplay);
 if ((!group.hasLocalOrRemoteStagingGroup() || !PropsValues.STAGING_LIVE_GROUP_LOCKING_ENABLED) && PortletPermissionUtil.contains(permissionChecker, themeDisplay.getScopeGroupId(), curLayout, portlet, ActionKeys.CONFIGURATION)) {
 	showConfigurationIcon = true;
 
-	boolean supportsConfigurationLAR = portlet.getConfigurationActionInstance() != null;
+	boolean supportsConfigurationLAR = configurationAction != null;
 	boolean supportsDataLAR = !(portlet.getPortletDataHandlerInstance() instanceof DefaultConfigurationPortletDataHandler);
 
 	if (supportsConfigurationLAR || supportsDataLAR || !group.isControlPanel()) {
@@ -444,9 +445,11 @@ portletDisplay.setURLClose(urlClose);
 PortletURL urlConfiguration = PortletProviderUtil.getPortletURL(request, PortletConfigurationApplicationType.PortletConfiguration.CLASS_NAME, PortletProvider.Action.VIEW);
 
 if (urlConfiguration != null) {
-	urlConfiguration.setWindowState(LiferayWindowState.POP_UP);
+	if (configurationAction != null) {
+		portletDisplay.setUrlConfigurationWindowState(configurationAction.getWindowsState());
 
-	if (portlet.getConfigurationActionInstance() != null) {
+		urlConfiguration.setWindowState(configurationAction.getWindowsState());
+
 		urlConfiguration.setParameter("mvcPath", "/edit_configuration.jsp");
 
 		String settingsScope = (String)request.getAttribute(WebKeys.SETTINGS_SCOPE);
@@ -458,6 +461,8 @@ if (urlConfiguration != null) {
 		}
 	}
 	else {
+		urlConfiguration.setWindowState(LiferayWindowState.POP_UP);
+
 		urlConfiguration.setParameter("mvcPath", "/edit_sharing.jsp");
 	}
 
@@ -796,7 +801,7 @@ if (group.isControlPanel()) {
 	portletDisplay.setShowMoveIcon(false);
 	portletDisplay.setShowPortletCssIcon(false);
 
-	if (!portlet.isPreferencesUniquePerLayout() && (portlet.getConfigurationActionInstance() != null) && PortletPermissionUtil.contains(permissionChecker, themeDisplay.getScopeGroupId(), curLayout, portlet, ActionKeys.CONFIGURATION)) {
+	if (!portlet.isPreferencesUniquePerLayout() && (configurationAction != null) && PortletPermissionUtil.contains(permissionChecker, themeDisplay.getScopeGroupId(), curLayout, portlet, ActionKeys.CONFIGURATION)) {
 		portletDisplay.setShowConfigurationIcon(true);
 	}
 }


### PR DESCRIPTION
- LPS-198638 Add step to assert page loaded
- LRQA-83596 Removes unnecessary test on master, since we are not supporting soy FormField
- LRQA-83695 Removes unnecessary test on master, since we are not supporting soy FormField
- COMMERCE-12362 Improve macro
- COMMERCE-12362 Add macro
- COMMERCE-12362 Add new paths
- COMMERCE-12362 Improve macro changeQuantityByUsingKeyArrows
- COMMERCE-12362 Add new tests
- COMMERCE-12362 Auto SF
- COMMERCE-12362 Fix custom properties for CanPriceOnApplicationWithUOMBeShownInMiniCart
- COMMERCE-12522 Add locators
- COMMERCE-12522 Improve viewMiniCartItem macro
- COMMERCE-12522 Add test CanAddToCartStaticPriceBundledProductWithUOM
- LPS-195519 Remove focus styles, there is another active status
- LPS-198690 - Apply --control-menu-container-height css variable to frontend-theme-styled.
- LPS-198686 - Apply --control-menu-container-height css variable to product-navigation-control-menu-theme-contributor.
- LPS-198684 - Apply --control-menu-container-height css variable to site-navigation-admin-web.
- LPS-198690 SF
- LPS-198570 Remove namespace prop from ChangeTrackingRenderView component
- LPS-198570 Replace updatePreviewRender logic with createPortletURL, which does the same thing
- LPS-198799 source-formatter: adds missing double-quotes
- LPS-198639 Add feature flag to test
- COMMERCE-12396 Add Path
- COMMERCE-12396 Add Test CanAddToCartMultipleSkusProductWithUOMs
- LPS-198676 Renamed feature flag
- LPS-193530 Add one more functional test on CanClickOverEndpointPath
- LPS-187121 Unignore CanGenerateOpenAPIForObjectWithRelationshipToUnpublishedObject test
- LPS-187121 Remove duplicate path for schema
- LPS-198645 Convert the Optional Dynamic Greedy references to static references using Snapshot in CleanUpStoreAreasSchedulerJobConfiguration
- LPS-198645 SF
- LPS-198646 Convert the Optional Dynamic Greedy references to static references using Snapshot in DDMStructureLocalServiceImpl
- LPS-198646 Remove unused reference field _xsdDDMFormDeserializer, its usages was removed by dbb6a6afba7063ceab70656457eea0264c731623
- LPS-197944 Freemark syntax error correction
- LPS-198180 Remove 10 item limit
- LPS-198180 Set a max height of 500px
- LPS-198180 Update the case for requirement changes
- ISSD-768 Fix Blank MDF Request ID in MDF Request and MDF Claim Details
- ISSD-766 Fix "See MDF Home" button
- ISSD-767 Fix "See Deals" button
- ISSD-767 Remove unused staging configuration
- ISSD-767 Fix build error for React app
- LPS-198628 Set currency in deal amount field
- LPS-198628 SF
- LRAC-14680 Add new test ViewKeywordSearchedNewStringParameter
- LRAC-14680 Fix group name
- LRAC-14680 Remove unneccessary steps
- LRAC-14680 Navigate to correct page
- LRAC-14680 Update test with new file name
- LPS-196902 upgrade testcase to firstLoginPG
- LPS-198146 Set lead type and lead owner in deal reg form
- LPS-198110 Cannot create Marketplace via tomcat
- LRAC-14716 Delete automation that was created with incorrect product behavior
- LPS-198809 Move ModelSearchConfigurator's states into its tracker.
- LPS-198809 Merge ModelSearchDefinition into ModelSearchConfigurator
- LPS-198809 Apply usages
- LPS-198809 Fix inconsistent naming
- LPS-198809 Allow ModelSearchConfigurator to return class name
- LPS-198809 No one ever set commitImmediately to ModelSearchSettings, it is always default to false
- LPS-198809 No one ever set searchClassNames
- LPS-198809 Move ModelSearchSettings creation out of ModelSearchConfigurator
- LPS-198809 Provide default impls for all optional methods.
- LPS-198809 Fix inconsistent naming
- LPS-198809 Apply to account-service
- LPS-198809 Apply to address-impl
- LPS-198809 Apply to asset-categories-service
- LPS-198809 Apply to asset-tags-service
- LPS-198809 Apply to blogs-service
- LPS-198809 Apply to bookmarks-service
- LPS-198809 Apply to calendar-service
- LPS-198809 Apply to change-tracking
- LPS-198809 Apply to commerce-inventory-service
- LPS-198809 Apply to commerce-order-rule-service
- LPS-198809 Apply to commerce-payment-service
- LPS-198809 Apply to commerce-product-service
- LPS-198809 Apply to commerce-product-type-grouped-service
- LPS-198809 Apply to commerce-service
- LPS-198809 Apply to commerce-shop-by-diagram-service
- LPS-198809 Apply to commerce-term-service
- LPS-198809 Apply to contacts-service
- LPS-198809 Apply to data-engine-service
- LPS-198809 Apply to depot-service
- LPS-198809 Apply to document-library-service
- LPS-198809 Apply to dynamic-data-lists-service
- LPS-198809 Apply to dynamic-data-mapping-service
- LPS-198809 Apply to export-import-service
- LPS-198809 Apply to journal-service
- LPS-198809 Apply to layout-impl
- LPS-198809 Apply to list-type-service
- LPS-198809 Apply to message-boards-service
- LPS-198809 Apply to notification-service
- LPS-198809 Apply to notifications-service
- LPS-198809 Apply to object-service
- LPS-198809 Apply to organizations-service
- LPS-198809 Apply to portal-workflow-kaleo-service
- LPS-198809 Apply to redirect-service
- LPS-198809 Apply to segments-service
- LPS-198809 Apply to translation-service
- LPS-198809 Apply to user-groups-admin-impl
- LPS-198809 Apply to users-admin-impl
- LPS-198809 Apply to search-experiences-service
- LPS-198809 Remove ModelSearchRegistrarHelper, not used anymore
- LPS-198809 Remove ModelSearchConfiguratorImpl
- LPS-198809 Remove all setters, no used anymore
- LPS-198809 Semantic versioning
- LPS-77699 Update Translations
- LPS-198068 Set the fileEntryId as well when importing field that has this value
- LPS-188951 Fixing test by using a valid hostname
- COMMERCE-12455 Update macros
- COMMERCE-12455 Add tests
- LPS-198601 skip tests for future refactoring
- LPS-198462 Remove nonexistent package
- LPS-198462 Auto SF
- LPS-198751 Prevent <aui:model-context /> from rendering the value in <aui:input>
- LPS-198669 No need to create a StringBundler if references is empty
- LPS-196963 Change text color to meet minimum constrast
- COMMERCE-12362 Fix macro setQuantitySelectorPopoverListItemText
- COMMERCE-12362 Add new paths
- COMMERCE-12362 Add new tests
- COMMERCE-12362 Auto SF
- LPS-198681 - Apply --control-menu-container-height css variable to analytics-reports-web.
- LPS-198461 Remove unused PageRenderer.soy
- LPS-198455 Fix condition that determines if a SegmentsExperience is associated with the default SegmentEntry
- LPS-198854 Rename
- LRCI-3790 Fix checks for confirming that a jenkins build completed
- LRCI-3790 prep next
- LPS-191014 Render the system site’s default language when creating a form
- LPS-191014 Show page success messages using the system site’s default language
- LRCI-3790 Include default parameters when invoking every build
- LRCI-3790 prep next
- LPS-198060 Unrelated. Remove unused reference
- LPS-198060 Make getPayload public
- LPS-198060 Add struts action to find layouts
- LPS-198060 Display all layouts returned by search instead of only the first 10.
- LPS-198060 Send findLayoutsURL
- LPS-198060 Remove .es extension
- LPS-198060 Rename
- LPS-198060 Add search results components and functions
- LPS-198060 We will filter in SearchResult component
- LPS-198060 Render SearchResults when there's filter
- LPS-198272 Fix the regex to include a colon, to find when the variable is declared inside the for
- LPS-198272 Replace the String type variable with StringUtil
- LPS-198272 SF
- LPS-198895 Reorder the step to add a web content with template
- LPS-198896 Update contentType in case to match the macro's setting
- LPS-198902 Add a tab step in case for the link added in LPS-187651
- LPS-198903 Reorder the step to select template at first
- LPS-198895 sf
- LPS-195585 Add path to see a disable select field into Actions tab
- LPS-195585 Add addActions macro
- LPS-198139 - Trigger validation on edit
- LPS-198139 - Trigger validation only on edit mode
- LPS-198139 - Toggle save button for edition mode
- LPS-195585 Add CanSeeModalWhenClicksOnEditAction test
- LPS-195585 Add CannotEditTypeField test
- LPS-195585 Add CanFillOnlyMandatoryFields test
- LPS-195585 Add CannotSaveLabelFieldEmpty test
- LPS-195585 Add CannotSaveURLFieldEmpty test
- LPS-195585 Add CanSaveAfterChangeAllFields test
- LPS-195585 Add CanCancelEditions test
- LPS-195585 Fix path in CanCancelChangesOnActions test
- LPS-192413 Follow up PR - fix test
- LPS-192413 Follow up PR - checks if each pattern contained in replacements.json is individually affecting the UpgradeCatchAllCheck testcase
- LPS-192413 Follow up PR - generalize the validation of UpgradeCatchAllCheck's test messages
- LPS-192413 Follow up PR - SF, comments removal
- LPS-192413 Rename to simplify
- LPS-192413 Wordsmith
- LPS-192413 Inline
- LPS-192413 Not needed
- LPS-192413 Simplify for the future
- LPS-173047 Inactive users are exported to LDAP, but anonymous users shouldn't be.. Create anonymous user configuration entry before inactivating the newly created anonymous user. This way LDAPUserExporter can check if an anonymous user is being exported.
- LPS-173047 Cannot deactivate a user without a group
- LPS-173047 Add contact as well
- LPS-173047 Fix filter in LDAPUserExporterImpl
- LPS-173047 Rename
- LPS-173047 Fix LPS-176887: Upgrades in UserAssociatedDataWebUpgradeStepRegistrator never run because of missing Release_ table entry
- LPS-173047 Add test
- LPS-173047 Use default locale if ThemeDisplay locale is not available
- LPS-173047 Avoid stale object state
- LPS-173047 Use getMostRelevantLocale instead
- LPS-197415 fix messages to match the behavior
- LPS-197415 make messages changes on copy size limits configuration
- LPS-197415 show info on the configuration page
- LPS-197415 add the type to the number inputs of the configurations
- LPS-197415 change configuration name
- LPS-197415 change name and add a new title to the conf
- LPS-197415 change poshi test
- LPS-197415 buildLang
- LPS-197415 Change labels on Poshi test
- LPS-197415 Update macro to use the suitable path
- LPS-197415 Wordsmith
- LPS-197415 Regen
- LPS-195074 Remove the Propagation message from the control menu for page templates, display pages, and master pages
- LPS-195074 Remove the Information message from the control menu for page templates, display pages, and master pages
- LPS-195074 SF, adapt naming
- LPS-195074 SF, advances cheapest conditions to prevent fetch the LayoutPageTemplateEntry if is not necessary
- LPS-195074 Take into account that the utility page don't propagate changes
- LPS-195074 Adds required dependency
- LPS-195074 SF
- LPS-196851 Add the logic to copy with permissions for Layout Page Templates
- LPS-196851 ServiceBuilder
- LPS-196851 Add the options of copy with and without permissions in the dropdown for Display Pages
- LPS-197156 Add the options of copy with and without permissions in the dropdown for Master Pages
- LPS-197156 Add FF
- LPS-197156 buildLang
- LPS-196851 Adapt Integration tests
- LPS-197156 SF
- LPS-198109 Add helper method to get a ctEntry's change type. Changes are displayed as deleted if
- LPS-198109 Apply usages of getChangeType
- LPS-198109 Add constatns for change type labels
- LPS-198109 Add filterable field name for changeType
- LPS-198109 Fix changeType filter
- LPS-198109 Semver
- LPS-196918 Create new language key
- LPS-196918 BuildLang
- LPS-196918 Change message show when trying to publish an already published object
- LPS-196918 Wordsmith
- LPS-196918 Regen
- LPS-196283 Create JSONStringStdDeserealizer to deserialize those properties which will be annotated in the dto of the entity
- LPS-196283 Allow parsing to string parameter using the objectMapper given JsonDeserializer annotation
- LPS-196283 Add x-json-string extended property in Schema and YamlUtil in the RESTBuilder control deserialize annotation
- LPS-196283 Add @JsonDeserialize  annotation setting the JsonDeserialize from portal-vulcan
- LPS-196283 Add x-json-string extended properties
- LPS-196283 buildREST
- LPS-196283 Add test case to POST WorklowDefinition using different types of content JSONs format
- LPS-196283 Add test for Batch Engine to POST WorklowDefinition using different types of content JSON format
- LPS-196283 Testing with unit tests
- LPS-196283 Moving inside the method
- LPS-196283 Adding vulcan tests
- LPS-196283 Supporting all json types (array...)
- LPS-196283 Asserting the content is the expected one
- LPS-196283 Buy space
- LPS-196283 Removing extra space
- LPS-196283 This reads much better
- LPS-196283 SF
- LPS-196283 prep next
- LPS-192413 prep next
- LPS-196283 prep next
- LPS-197156 SF
- COMMERCE-12404 Add new paths
- COMMERCE-12404 Adapt JSON macro
- COMMERCE-12404 Add functional tests
- ISSD-50 Fix send slack message
- LPS-198426 Isolate search predicate with parentheses always
- LPS-195696 We need to follow the same approach for focusManager than we followed previously for overlays in LPS-130738, so we'll have a map of them using the trigger as a key, otherwise it gets messed up when we have more than one in the same page
- LPS-195696 Remove the map when navigating through pages using SPA so we don't reuse focusManagerMap in a new fresh page
- LPS-198934 Fix Next Step text for Trial Option
- LPS-192413 Follow up - create the exception package for source-formatter module
- LPS-192413 Follow up - update import of source-formatter's custom exceptions
- LPS-198887 Update icons for Web Content items
- LPS-197078 - Change dropdown pagination-items-per-page to have same behavior as Clay Picker
- LPS-197078 - Add removeEventListener to avoid memory link issues and getElementById on dropdown
- LPS-197078 - Remove removeEventListener form inside the loop and code cleanup
- LPS-197078 - Add Esc key events, use Liferay.once instead Liferay.on, and code cleanup
- LPS-197078 - Add focus on dropdown button after Escape key press and code cleanup
- LPS-197078 - Code clean up and moving tag script inside if block.
- LPS-197078 - code cleanup and wrap content of script in IIFE
- LPS-197078 - SF
- LPS-197078 SF
- LPS-198524 Use title instead of data-title and aria-label instead od aria-labelledby for ai creator button for web contents
- LPS-198524 Fix message value for LearnMessage
- LPS-191342 Add new page size limit configuration
- LPS-191342 Add new language keys
- LPS-191342 Set a page and pageSize based on the limit configuration and the parameters requested by the user
- LPS-191342 Fixed test which used a PaginationContextProvider without arguments
- LPS-191342 Create tests
- LPS-191342 buildLang
- LPS-191342 Simplifying with early returns
- LPS-191342 Simpler with just 1 int
- LPS-191342 Wordsmith
- LPS-191342 Regen
- LPS-191342 SF
- LPS-191342 SF
- LPS-191342 Inline
- LPS-191342 Rename
- LPS-191342 SF
- LPS-197820 create new app to save content
- LPS-197820 add new app structure
- LPS-197820 add tables and service of save content entry
- LPS-197820 buildService
- LPS-197820 add needed dependencies and exports
- LPS-197820 AutoSF
- LPS-197820 Consistency
- LRDOCS-11563 altered language keys
- LRDOCS-11563 Wordsmith
- LRDOCS-11563 Regen
- LPS-198698 If the value is zero just dont add any decimal
- LPS-198963 Fix tests
- LPS-198287 Set overflow visible to avoid double scroll in a line
- LPS-198787 portal-search-tuning-rankings-web: update naming to match 130c97887316224e930248854d265bac6c418b11
- LPS-198787 portal-search-tuning-rankings-web: update tests
- LPS-197744 portal-search-tuning-rankings-web: Dont apply any rankings when editing rankings
- LPS-198937 Use product-menu-open class
- LRCI-3673 SF
- LRCI-3673 Don't allow "test" to be a redact token
- LRCI-3673 Use SecureProperties
- LRCI-3673 Return immediately if there is no bearer token
- LRCI-3673 Simplify
- LRCI-3673 prep next
- LPS-198272 Follow up - Fix ConfigurationEnvBuilderTest for use in removeSubstring method the com.liferay.portal.kernel.util.StringUtil class
- LPS-198272 SF
- LRQA-83580 Update system check assert
- LPS-198807 Workaround to work on sandbox and production DocuSign environment
- LPS-197107 File should come before folder
- LPS-197107 SF
- LPS-197107 Add logic to sort file names in gradle file
- LPS-197107 Add testcase
- LPS-197107 Auto SF
- LPS-197107 SF
- LPS-197107 Use PropertyValueComparator
- LPS-197107 Rename
- LPS-197107 Set initial capacity of StringBundler
- LPS-197107 SF
- LPS-197901 SF, avoid chaining on Type Cast
- LPS-197901 prep next
- LPS-197901 prep next
- LRQA-83599 Change fragment name to paragraph for welcome message
- LRQA-83404 Test with different feature flag
- LPS-195638 Add addFrontendDataSetFilter macro
- LPS-195638 Add CanViewFiltersCXInDataSetFragment test
- LPS-195638 Add CanViewCXOptionsInDataSetFragment test
- LPS-195638 Add new FF to the testcase
- LPS-195638 Add CX filter to dependencies
- LPS-198185 With some display settings, simple menu is not rendered
- LPS-198335 - Remove unneeded h4
- LPS-198694 - Apply --control-menu-container-height css variable to content-dashboard-web.
- LPS-198689 - Apply --control-menu-container-height css variable to journal-web.
- LPS-198687 - Apply --control-menu-container-height css variable to layout-content-page-editor-web.
- LPS-198685 - Apply --control-menu-container-height css variable to product-navigation-simulation-device.
- LPS-198683 - Apply --control-menu-container-height css variable to style-book-web.
- LPS-198682 - Apply --control-menu-container-height css variable to template-web.
- LPS-190803 Ensure the elements ordering for assertion
- LPS-192081 Rename ProcessBuilderSource to ProcessBuilderCE
- LPS-198910 Actions for entries and folders differ, so take this into account
- LPS-198910 The users can delete the collection either as a folder or as a page template set, so change dialog accordingly
- LPS-198910 We are no longer deleting only display page entries, but also folders. So use a generic term in the modal for them
- LPS-198910 According to the design, we should show only rename for folders in display pages, not edit. The other way around for page template sets
- LPS-198700 Replace non-blocking ServiceProxyFactory usages by using Snapshot in FullNameGeneratorFactory
- LPS-198700 Remove redundant Spring configuration for DefaultFullNameGenerator
- LPS-198700 Semantic Versioning
- LPS-198995 Convert xml content from the '**workflow**.json' files to the x-json format
- LPS-198995 #sfme only for JSON with cdata-value like this
- LPS-197963 Add readonly for text field
- LPS-197963 Add readonly for textarea field
- LPS-197963 Add readonly for numeric field
- LPS-197963 Add readonly for rich text field
- LPS-197963 Add readonly for multi select field
- LPS-197963 Add readonly for checkbox field
- LPS-164561 Add readonly for date field
- LPS-164561 Add readonly for date-time field
- LPS-164561 Add aria-labelled by to the date-field along with its respective error
- LPS-164561 Add readonly for select from list field
- LPS-164561 Add readonly for select file upload field
- LPS-164561 Add missing for='' to labels
- LPS-198338 Adds new attribute for readOnly to the infoField builder
- LPS-198338 Baseline
- LPS-198338 Default value is false for readOnly. READ_ONLY_CONDITIONAL is also treated as false
- LPS-198338 Adds readOnly attribute to inputTemplateNode, and adapt accordingly
- LPS-198338 Adds the attribute to inputTemplateNode
- LPS-198338 Hide behind FF
- LPS-198338 Baseline
- WIP
