### PR TITLE
WIP

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/JournalConfigurationAction.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/JournalConfigurationAction.java
@@ -23,6 +23,7 @@ import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
 import javax.portlet.PortletConfig;
 import javax.portlet.PortletRequest;
+import javax.portlet.WindowState;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -47,6 +48,11 @@ public class JournalConfigurationAction
 	@Override
 	public String getJspPath(HttpServletRequest httpServletRequest) {
 		return "/configuration.jsp";
+	}
+
+	@Override
+	public WindowState getWindowsState() {
+		return WindowState.MAXIMIZED;
 	}
 
 	@Override

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/configuration/icon/BaseConfigurationPortletConfigurationIcon.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/configuration/icon/BaseConfigurationPortletConfigurationIcon.java
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portlet.configuration.web.internal.portlet.configuration.icon;
+
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.portlet.configuration.icon.BaseJSPPortletConfigurationIcon;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+
+import java.util.Map;
+
+import javax.portlet.PortletRequest;
+
+/**
+ * @author Jürgen Kappler
+ */
+public abstract class BaseConfigurationPortletConfigurationIcon
+	extends BaseJSPPortletConfigurationIcon {
+
+	@Override
+	public Map<String, Object> getContext(PortletRequest portletRequest) {
+		return HashMapBuilder.<String, Object>put(
+			"action", getNamespace(portletRequest) + "configuration"
+		).put(
+			"globalAction", true
+		).build();
+	}
+
+	@Override
+	public String getCssClass() {
+		return "portlet-configuration portlet-configuration-icon";
+	}
+
+	@Override
+	public String getIconCssClass() {
+		return "cog";
+	}
+
+	@Override
+	public String getMessage(PortletRequest portletRequest) {
+		return LanguageUtil.get(getLocale(portletRequest), "configuration");
+	}
+
+	@Override
+	public double getWeight() {
+		return 14.0;
+	}
+
+	@Override
+	public boolean isShowInEditMode(PortletRequest portletRequest) {
+		return true;
+	}
+
+}

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/configuration/icon/BasicConfigurationPortletConfigurationIcon.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/configuration/icon/BasicConfigurationPortletConfigurationIcon.java
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portlet.configuration.web.internal.portlet.configuration.icon;
+
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.portlet.LiferayWindowState;
+import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
+import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
+import com.liferay.portal.kernel.theme.PortletDisplay;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import javax.portlet.PortletRequest;
+import javax.portlet.PortletResponse;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Eudaldo Alonso
+ */
+@Component(service = PortletConfigurationIcon.class)
+public class BasicConfigurationPortletConfigurationIcon
+	extends BasePortletConfigurationIcon {
+
+	@Override
+	public String getURL(
+		PortletRequest portletRequest, PortletResponse portletResponse) {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+		return portletDisplay.getURLConfiguration();
+	}
+
+	@Override
+	public boolean isShow(PortletRequest portletRequest) {
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		Layout layout = themeDisplay.getLayout();
+
+		if (layout.isEmbeddedPersonalApplication()) {
+			return false;
+		}
+
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+		if (portletDisplay.getURLConfigurationWindowState() ==
+				LiferayWindowState.POP_UP) {
+
+			return false;
+		}
+
+		return portletDisplay.isShowConfigurationIcon();
+	}
+
+}

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/configuration/icon/JsConfigurationPortletConfigurationIcon.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/configuration/icon/JsConfigurationPortletConfigurationIcon.java
@@ -5,16 +5,12 @@
 
 package com.liferay.portlet.configuration.web.internal.portlet.configuration.icon;
 
-import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.portlet.configuration.icon.BaseJSPPortletConfigurationIcon;
+import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.WebKeys;
-
-import java.util.Map;
 
 import javax.portlet.PortletRequest;
 
@@ -27,41 +23,12 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eudaldo Alonso
  */
 @Component(service = PortletConfigurationIcon.class)
-public class ConfigurationPortletConfigurationIcon
-	extends BaseJSPPortletConfigurationIcon {
-
-	@Override
-	public Map<String, Object> getContext(PortletRequest portletRequest) {
-		return HashMapBuilder.<String, Object>put(
-			"action", getNamespace(portletRequest) + "configuration"
-		).put(
-			"globalAction", true
-		).build();
-	}
-
-	@Override
-	public String getCssClass() {
-		return "portlet-configuration portlet-configuration-icon";
-	}
-
-	@Override
-	public String getIconCssClass() {
-		return "cog";
-	}
+public class JsConfigurationPortletConfigurationIcon
+	extends BaseConfigurationPortletConfigurationIcon {
 
 	@Override
 	public String getJspPath() {
 		return "/configuration/icon/configuration.jsp";
-	}
-
-	@Override
-	public String getMessage(PortletRequest portletRequest) {
-		return _language.get(getLocale(portletRequest), "configuration");
-	}
-
-	@Override
-	public double getWeight() {
-		return 14.0;
 	}
 
 	@Override
@@ -77,21 +44,19 @@ public class ConfigurationPortletConfigurationIcon
 
 		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
 
-		return portletDisplay.isShowConfigurationIcon();
-	}
+		if (portletDisplay.getURLConfigurationWindowState() !=
+				LiferayWindowState.POP_UP) {
 
-	@Override
-	public boolean isShowInEditMode(PortletRequest portletRequest) {
-		return true;
+			return false;
+		}
+
+		return portletDisplay.isShowConfigurationIcon();
 	}
 
 	@Override
 	protected ServletContext getServletContext() {
 		return _servletContext;
 	}
-
-	@Reference
-	private Language _language;
 
 	@Reference(
 		target = "(osgi.web.symbolicname=com.liferay.portlet.configuration.web)"

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 127.0.1
+Bundle-Version: 127.1.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/ConfigurationAction.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/ConfigurationAction.java
@@ -8,6 +8,7 @@ package com.liferay.portal.kernel.portlet;
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
 import javax.portlet.PortletConfig;
+import javax.portlet.WindowState;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -16,6 +17,10 @@ import javax.servlet.http.HttpServletResponse;
  * @author Brian Wing Shun Chan
  */
 public interface ConfigurationAction {
+
+	public default WindowState getWindowsState() {
+		return LiferayWindowState.POP_UP;
+	}
 
 	public void include(
 			PortletConfig portletConfig, HttpServletRequest httpServletRequest,

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/packageinfo
@@ -1,1 +1,1 @@
-version 27.0.0
+version 27.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/theme/PortletDisplay.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/theme/PortletDisplay.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
+import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIconMenu;
 import com.liferay.portal.kernel.portlet.toolbar.PortletToolbar;
 import com.liferay.portal.kernel.util.Constants;
@@ -28,6 +29,7 @@ import java.io.Serializable;
 import java.io.Writer;
 
 import javax.portlet.PortletPreferences;
+import javax.portlet.WindowState;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -115,6 +117,7 @@ public class PortletDisplay implements Cloneable, Serializable {
 		_urlClose = master.getURLClose();
 		_urlConfiguration = master.getURLConfiguration();
 		_urlConfigurationJS = master.getURLConfigurationJS();
+		_urlConfigurationWindowState = master.getURLConfigurationWindowState();
 		_urlEdit = master.getURLEdit();
 		_urlEditDefaults = master.getURLEditDefaults();
 		_urlEditGuest = master.getURLEditGuest();
@@ -185,6 +188,7 @@ public class PortletDisplay implements Cloneable, Serializable {
 		slave.setURLClose(_urlClose);
 		slave.setURLConfiguration(_urlConfiguration);
 		slave.setURLConfigurationJS(_urlConfigurationJS);
+		slave.setUrlConfigurationWindowState(_urlConfigurationWindowState);
 		slave.setURLEdit(_urlEdit);
 		slave.setURLEditDefaults(_urlEditDefaults);
 		slave.setURLEditGuest(_urlEditGuest);
@@ -304,6 +308,10 @@ public class PortletDisplay implements Cloneable, Serializable {
 
 	public String getURLConfigurationJS() {
 		return _urlConfigurationJS;
+	}
+
+	public WindowState getURLConfigurationWindowState() {
+		return _urlConfigurationWindowState;
 	}
 
 	public String getURLEdit() {
@@ -599,6 +607,7 @@ public class PortletDisplay implements Cloneable, Serializable {
 		_urlBack = StringPool.BLANK;
 		_urlClose = StringPool.BLANK;
 		_urlConfiguration = StringPool.BLANK;
+		_urlConfigurationWindowState = LiferayWindowState.POP_UP;
 		_urlEdit = StringPool.BLANK;
 		_urlEditDefaults = StringPool.BLANK;
 		_urlEditGuest = StringPool.BLANK;
@@ -865,6 +874,12 @@ public class PortletDisplay implements Cloneable, Serializable {
 		_urlConfigurationJS = urlConfigurationJS;
 	}
 
+	public void setUrlConfigurationWindowState(
+		WindowState urlConfigurationWindowState) {
+
+		_urlConfigurationWindowState = urlConfigurationWindowState;
+	}
+
 	public void setURLEdit(String urlEdit) {
 		_urlEdit = urlEdit;
 	}
@@ -983,6 +998,8 @@ public class PortletDisplay implements Cloneable, Serializable {
 	private String _urlClose = StringPool.BLANK;
 	private String _urlConfiguration = StringPool.BLANK;
 	private String _urlConfigurationJS = StringPool.BLANK;
+	private WindowState _urlConfigurationWindowState =
+		LiferayWindowState.POP_UP;
 	private String _urlEdit = StringPool.BLANK;
 	private String _urlEditDefaults = StringPool.BLANK;
 	private String _urlEditGuest = StringPool.BLANK;

--- a/portal-kernel/src/com/liferay/portal/kernel/theme/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/theme/packageinfo
@@ -1,1 +1,1 @@
-version 11.1.0
+version 11.2.0

--- a/portal-web/docroot/html/portal/init.jsp
+++ b/portal-web/docroot/html/portal/init.jsp
@@ -26,6 +26,7 @@ page import="com.liferay.portal.kernel.exception.UserLockoutException" %><%@
 page import="com.liferay.portal.kernel.exception.UserPasswordException" %><%@
 page import="com.liferay.portal.kernel.exception.UserReminderQueryException" %><%@
 page import="com.liferay.portal.kernel.license.util.LicenseManagerUtil" %><%@
+page import="com.liferay.portal.kernel.portlet.ConfigurationAction" %><%@
 page import="com.liferay.portal.kernel.portlet.PortletConfigurationLayoutUtil" %><%@
 page import="com.liferay.portal.kernel.service.LayoutLocalServiceUtil" %><%@
 page import="com.liferay.portal.kernel.servlet.HttpHeaders" %><%@

--- a/portal-web/docroot/html/portal/render_portlet.jsp
+++ b/portal-web/docroot/html/portal/render_portlet.jsp
@@ -12,6 +12,7 @@ String cmd = ParamUtil.getString(request, Constants.CMD);
 
 Portlet portlet = (Portlet)request.getAttribute(WebKeys.RENDER_PORTLET);
 
+ConfigurationAction configurationAction = portlet.getConfigurationActionInstance();
 String portletId = portlet.getPortletId();
 String rootPortletId = portlet.getRootPortletId();
 String instanceId = portlet.getInstanceId();
@@ -180,7 +181,7 @@ Layout curLayout = PortletConfigurationLayoutUtil.getLayout(themeDisplay);
 if ((!group.hasLocalOrRemoteStagingGroup() || !PropsValues.STAGING_LIVE_GROUP_LOCKING_ENABLED) && PortletPermissionUtil.contains(permissionChecker, themeDisplay.getScopeGroupId(), curLayout, portlet, ActionKeys.CONFIGURATION)) {
 	showConfigurationIcon = true;
 
-	boolean supportsConfigurationLAR = portlet.getConfigurationActionInstance() != null;
+	boolean supportsConfigurationLAR = configurationAction != null;
 	boolean supportsDataLAR = !(portlet.getPortletDataHandlerInstance() instanceof DefaultConfigurationPortletDataHandler);
 
 	if (supportsConfigurationLAR || supportsDataLAR || !group.isControlPanel()) {
@@ -444,9 +445,11 @@ portletDisplay.setURLClose(urlClose);
 PortletURL urlConfiguration = PortletProviderUtil.getPortletURL(request, PortletConfigurationApplicationType.PortletConfiguration.CLASS_NAME, PortletProvider.Action.VIEW);
 
 if (urlConfiguration != null) {
-	urlConfiguration.setWindowState(LiferayWindowState.POP_UP);
+	if (configurationAction != null) {
+		portletDisplay.setUrlConfigurationWindowState(configurationAction.getWindowsState());
 
-	if (portlet.getConfigurationActionInstance() != null) {
+		urlConfiguration.setWindowState(configurationAction.getWindowsState());
+
 		urlConfiguration.setParameter("mvcPath", "/edit_configuration.jsp");
 
 		String settingsScope = (String)request.getAttribute(WebKeys.SETTINGS_SCOPE);
@@ -458,6 +461,8 @@ if (urlConfiguration != null) {
 		}
 	}
 	else {
+		urlConfiguration.setWindowState(LiferayWindowState.POP_UP);
+
 		urlConfiguration.setParameter("mvcPath", "/edit_sharing.jsp");
 	}
 
@@ -796,7 +801,7 @@ if (group.isControlPanel()) {
 	portletDisplay.setShowMoveIcon(false);
 	portletDisplay.setShowPortletCssIcon(false);
 
-	if (!portlet.isPreferencesUniquePerLayout() && (portlet.getConfigurationActionInstance() != null) && PortletPermissionUtil.contains(permissionChecker, themeDisplay.getScopeGroupId(), curLayout, portlet, ActionKeys.CONFIGURATION)) {
+	if (!portlet.isPreferencesUniquePerLayout() && (configurationAction != null) && PortletPermissionUtil.contains(permissionChecker, themeDisplay.getScopeGroupId(), curLayout, portlet, ActionKeys.CONFIGURATION)) {
 		portletDisplay.setShowConfigurationIcon(true);
 	}
 }


### PR DESCRIPTION
- LPS-WIP New method to specify the windows state for configuration actions
- LPS-WIP New method to specify the windows state configuration of widgets
- LPS-WIP Baseline
- LPS-WIP Take into account the window state of the configuration icon in render portlet
- LPS-WIP Add a new base class for configuration icon, since we want to have different behaviours depending on the windows state
- LPS-WIP Use base class
- LPS-WIP Change the windows state of JournalConfigurationAction so that it opens in a maximized view instead of popup
