### PR TITLE
LPD 31078 fragment resources

### DIFF
--- a/modules/apps/document-library/document-library-taglib-test/bnd.bnd
+++ b/modules/apps/document-library/document-library-taglib-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Document Library Taglib Test
+Bundle-SymbolicName: com.liferay.document.library.taglib.test
+Bundle-Version: 1.0.0

--- a/modules/apps/document-library/document-library-taglib-test/build.gradle
+++ b/modules/apps/document-library/document-library-taglib-test/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/apps/document-library/document-library-taglib-test/build.gradle
+++ b/modules/apps/document-library/document-library-taglib-test/build.gradle
@@ -1,3 +1,6 @@
 dependencies {
+	testIntegrationImplementation group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
+	testIntegrationImplementation project(":apps:document-library:document-library-taglib")
+	testIntegrationImplementation project(":apps:frontend-taglib:frontend-taglib-clay")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/document-library/document-library-taglib-test/build.gradle
+++ b/modules/apps/document-library/document-library-taglib-test/build.gradle
@@ -2,5 +2,7 @@ dependencies {
 	testIntegrationImplementation group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
 	testIntegrationImplementation project(":apps:document-library:document-library-taglib")
 	testIntegrationImplementation project(":apps:frontend-taglib:frontend-taglib-clay")
+	testIntegrationImplementation project(":apps:portal:portal-upload-test-util")
+	testIntegrationImplementation project(":apps:static:portal-osgi-web:portal-osgi-web-portlet-container-test-util")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/document-library/document-library-taglib-test/src/testIntegration/java/com/liferay/document/library/taglib/internal/servlet/test/RepositoryBrowserServletTest.java
+++ b/modules/apps/document-library/document-library-taglib-test/src/testIntegration/java/com/liferay/document/library/taglib/internal/servlet/test/RepositoryBrowserServletTest.java
@@ -1,0 +1,298 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.taglib.internal.servlet.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLAppService;
+import com.liferay.petra.memory.DeleteFileFinalizeAction;
+import com.liferay.petra.memory.FinalizeManager;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.test.context.ContextUserReplace;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.upload.FileItem;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upload.test.util.UploadTestUtil;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import java.util.HashMap;
+
+import javax.servlet.Servlet;
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.mock.web.MockMultipartHttpServletRequest;
+
+/**
+ * @author Jürgen Kappler
+ */
+@RunWith(Arquillian.class)
+public class RepositoryBrowserServletTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_user = UserTestUtil.addUser();
+	}
+
+	@Test
+	public void testDoPutFileEntryWithGuestPermissions() throws Exception {
+		String name = RandomTestUtil.randomString();
+
+		MockMultipartFile mockMultipartFile = new MockMultipartFile(
+			"file", _BYTES);
+
+		_servlet.service(
+			_getMockMultipartHttpServletRequest(name, mockMultipartFile, true),
+			new MockHttpServletResponse());
+
+		PermissionChecker permissionChecker = _permissionCheckerFactory.create(
+			_user);
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_user, permissionChecker)) {
+
+			_dlAppService.getFileEntry(
+				_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				name);
+		}
+	}
+
+	@Test(expected = PrincipalException.MustHavePermission.class)
+	public void testDoPutFileEntryWithoutGuestPermissions() throws Exception {
+		String name = RandomTestUtil.randomString();
+
+		MockMultipartFile mockMultipartFile = new MockMultipartFile(
+			"file", _BYTES);
+
+		_servlet.service(
+			_getMockMultipartHttpServletRequest(name, mockMultipartFile, false),
+			new MockHttpServletResponse());
+
+		PermissionChecker permissionChecker = _permissionCheckerFactory.create(
+			_user);
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_user, permissionChecker)) {
+
+			_dlAppService.getFileEntry(
+				_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				name);
+		}
+	}
+
+	@Test
+	public void testDoPutFolderWithGuestPermissions() throws Exception {
+		String name = RandomTestUtil.randomString();
+
+		_servlet.service(
+			_getMockHttpServletRequest(name, true),
+			new MockHttpServletResponse());
+
+		PermissionChecker permissionChecker = _permissionCheckerFactory.create(
+			_user);
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_user, permissionChecker)) {
+
+			_dlAppService.getFolder(
+				_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				name);
+		}
+	}
+
+	@Test(expected = PrincipalException.MustHavePermission.class)
+	public void testDoPutFolderWithoutGuestPermissions() throws Exception {
+		String name = RandomTestUtil.randomString();
+
+		_servlet.service(
+			_getMockHttpServletRequest(name, false),
+			new MockHttpServletResponse());
+
+		PermissionChecker permissionChecker = _permissionCheckerFactory.create(
+			_user);
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_user, permissionChecker)) {
+
+			_dlAppService.getFolder(
+				_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				name);
+		}
+	}
+
+	private FileItem _createFileItem(byte[] bytes, String fileName)
+		throws Exception {
+
+		Path tempFilePath = Files.createTempFile(null, ".txt");
+
+		Files.write(tempFilePath, bytes);
+
+		File tempFile = tempFilePath.toFile();
+
+		FinalizeManager.register(
+			tempFile, new DeleteFileFinalizeAction(tempFile.getAbsolutePath()),
+			FinalizeManager.PHANTOM_REFERENCE_FACTORY);
+
+		return ProxyUtil.newDelegateProxyInstance(
+			FileItem.class.getClassLoader(), FileItem.class,
+			new Object() {
+
+				public void delete() {
+					tempFile.delete();
+				}
+
+				public String getContentType() {
+					return StringPool.BLANK;
+				}
+
+				public String getFileName() {
+					return fileName;
+				}
+
+				public String getFullFileName() {
+					return tempFile.getName();
+				}
+
+				public InputStream getInputStream() throws IOException {
+					return new FileInputStream(tempFile);
+				}
+
+				public long getSize() {
+					return bytes.length;
+				}
+
+				public int getSizeThreshold() {
+					return 1024;
+				}
+
+				public File getStoreLocation() {
+					return tempFile;
+				}
+
+				public boolean isFormField() {
+					return true;
+				}
+
+				public boolean isInMemory() {
+					return false;
+				}
+
+			},
+			null);
+	}
+
+	private MockHttpServletRequest _getMockHttpServletRequest(
+			String name, boolean viewableByGuest)
+		throws Exception {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.CURRENT_URL, RandomTestUtil.randomString());
+		mockHttpServletRequest.setAttribute(
+			WebKeys.USER, TestPropsValues.getUser());
+		mockHttpServletRequest.setMethod("PUT");
+		mockHttpServletRequest.setParameter("name", name);
+		mockHttpServletRequest.setParameter(
+			"repositoryId", String.valueOf(_group.getGroupId()));
+		mockHttpServletRequest.setParameter(
+			"viewableByGuest", String.valueOf(viewableByGuest));
+
+		return mockHttpServletRequest;
+	}
+
+	private HttpServletRequest _getMockMultipartHttpServletRequest(
+			String fileName, MockMultipartFile mockMultipartFile,
+			boolean viewableByGuest)
+		throws Exception {
+
+		MockMultipartHttpServletRequest mockMultipartHttpServletRequest =
+			new MockMultipartHttpServletRequest();
+
+		mockMultipartHttpServletRequest.addFile(mockMultipartFile);
+		mockMultipartHttpServletRequest.setContent(_BYTES);
+		mockMultipartHttpServletRequest.setAttribute(
+			WebKeys.CURRENT_URL, RandomTestUtil.randomString());
+		mockMultipartHttpServletRequest.setAttribute(
+			WebKeys.USER, TestPropsValues.getUser());
+		mockMultipartHttpServletRequest.setCharacterEncoding("UTF-8");
+		mockMultipartHttpServletRequest.setMethod("PUT");
+		mockMultipartHttpServletRequest.setParameter(
+			"repositoryId", String.valueOf(_group.getGroupId()));
+		mockMultipartHttpServletRequest.setParameter(
+			"viewableByGuest", String.valueOf(viewableByGuest));
+
+		return UploadTestUtil.createUploadPortletRequest(
+			UploadTestUtil.createUploadServletRequest(
+				mockMultipartHttpServletRequest,
+				HashMapBuilder.put(
+					"file", new FileItem[] {_createFileItem(_BYTES, fileName)}
+				).build(),
+				new HashMap<>()),
+			null, RandomTestUtil.randomString());
+	}
+
+	private static final byte[] _BYTES =
+		"Enterprise. Open Source. For Life.".getBytes();
+
+	@Inject
+	private DLAppService _dlAppService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private PermissionCheckerFactory _permissionCheckerFactory;
+
+	@Inject(
+		filter = "osgi.http.whiteboard.servlet.name=com.liferay.document.library.taglib.internal.servlet.RepositoryBrowserServlet"
+	)
+	private Servlet _servlet;
+
+	@DeleteAfterTestRun
+	private User _user;
+
+}

--- a/modules/apps/document-library/document-library-taglib-test/src/testIntegration/java/com/liferay/document/library/taglib/servlet/taglib/test/RepositoryBrowserTagTest.java
+++ b/modules/apps/document-library/document-library-taglib-test/src/testIntegration/java/com/liferay/document/library/taglib/servlet/taglib/test/RepositoryBrowserTagTest.java
@@ -1,0 +1,184 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.taglib.servlet.taglib.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.taglib.servlet.taglib.RepositoryBrowserTag;
+import com.liferay.frontend.taglib.clay.servlet.taglib.display.context.ManagementToolbarDisplayContext;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemList;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletURL;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Jürgen Kappler
+ */
+@RunWith(Arquillian.class)
+public class RepositoryBrowserTagTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testViewableByGuest() throws PortalException {
+		RepositoryBrowserTag repositoryBrowserTag = new RepositoryBrowserTag();
+
+		repositoryBrowserTag.setRepositoryId(_group.getGroupId());
+
+		_assertViewableByGuest("false", repositoryBrowserTag);
+
+		repositoryBrowserTag.setViewableByGuest(true);
+
+		_assertViewableByGuest("true", repositoryBrowserTag);
+	}
+
+	private void _assertViewableByGuest(
+			String expectedViewableByGuestValue,
+			RepositoryBrowserTag repositoryBrowserTag)
+		throws PortalException {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			_getMockHttpServletRequest();
+
+		ReflectionTestUtil.setFieldValue(
+			repositoryBrowserTag, "_httpServletRequest",
+			mockHttpServletRequest);
+
+		ReflectionTestUtil.invoke(
+			repositoryBrowserTag, "setAttributes",
+			new Class<?>[] {HttpServletRequest.class},
+			new Object[] {mockHttpServletRequest});
+
+		Object repositoryBrowserTagDisplayContext =
+			mockHttpServletRequest.getAttribute(
+				"com.liferay.document.library.taglib.internal.display." +
+					"context.RepositoryBrowserTagDisplayContext");
+
+		ManagementToolbarDisplayContext managementToolbarDisplayContext =
+			ReflectionTestUtil.invoke(
+				repositoryBrowserTagDisplayContext,
+				"getManagementToolbarDisplayContext", new Class<?>[0]);
+
+		CreationMenu creationMenu =
+			managementToolbarDisplayContext.getCreationMenu();
+
+		DropdownItemList dropdownItemList = (DropdownItemList)creationMenu.get(
+			"primaryItems");
+
+		Assert.assertEquals(
+			dropdownItemList.toString(), 2, dropdownItemList.size());
+
+		DropdownItem dropdownItem = dropdownItemList.get(1);
+
+		Map<String, String> data = (Map<String, String>)dropdownItem.get(
+			"data");
+
+		Assert.assertEquals(
+			expectedViewableByGuestValue, data.get("viewableByGuest"));
+
+		Map<String, Object> repositoryBrowserComponentContext =
+			ReflectionTestUtil.invoke(
+				repositoryBrowserTagDisplayContext,
+				"getRepositoryBrowserComponentContext", new Class<?>[0]);
+
+		Assert.assertNotNull(repositoryBrowserComponentContext);
+
+		Assert.assertEquals(
+			expectedViewableByGuestValue,
+			repositoryBrowserComponentContext.get("viewableByGuest"));
+	}
+
+	private MockHttpServletRequest _getMockHttpServletRequest()
+		throws PortalException {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		String portletName = RandomTestUtil.randomString();
+
+		String attributeName = StringBundler.concat(
+			portletName, StringPool.DASH, WebKeys.CURRENT_PORTLET_URL);
+
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			new MockLiferayPortletRenderRequest() {
+
+				@Override
+				public String getPortletName() {
+					return portletName;
+				}
+
+			};
+
+		mockLiferayPortletRenderRequest.setAttribute(
+			attributeName, new MockLiferayPortletURL());
+
+		mockHttpServletRequest.setAttribute(
+			JavaConstants.JAVAX_PORTLET_REQUEST,
+			mockLiferayPortletRenderRequest);
+
+		mockHttpServletRequest.setAttribute(
+			JavaConstants.JAVAX_PORTLET_RESPONSE,
+			new MockLiferayPortletActionResponse());
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay());
+
+		return mockHttpServletRequest;
+	}
+
+	private ThemeDisplay _getThemeDisplay() throws PortalException {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
+		themeDisplay.setScopeGroupId(_group.getGroupId());
+
+		return themeDisplay;
+	}
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+}

--- a/modules/apps/document-library/document-library-taglib-test/test.properties
+++ b/modules/apps/document-library/document-library-taglib-test/test.properties
@@ -1,0 +1,5 @@
+##
+## Testray
+##
+
+    testray.main.component.name=Document Management

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserManagementToolbarDisplayContext.java
@@ -43,7 +43,7 @@ public class RepositoryBrowserManagementToolbarDisplayContext
 		HttpServletRequest httpServletRequest,
 		LiferayPortletRequest liferayPortletRequest,
 		LiferayPortletResponse liferayPortletResponse, long repositoryId,
-		SearchContainer<Object> searchContainer) {
+		SearchContainer<Object> searchContainer, boolean viewableByGuest) {
 
 		super(
 			httpServletRequest, liferayPortletRequest, liferayPortletResponse,
@@ -53,6 +53,7 @@ public class RepositoryBrowserManagementToolbarDisplayContext
 		_folderId = folderId;
 		_folderModelResourcePermission = folderModelResourcePermission;
 		_repositoryId = repositoryId;
+		_viewableByGuest = viewableByGuest;
 
 		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
@@ -127,6 +128,8 @@ public class RepositoryBrowserManagementToolbarDisplayContext
 					"parentFolderId", String.valueOf(_folderId));
 				dropdownItem.putData(
 					"repositoryId", String.valueOf(_repositoryId));
+				dropdownItem.putData(
+					"viewableByGuest", String.valueOf(_viewableByGuest));
 				dropdownItem.setIcon("folder");
 				dropdownItem.setLabel(
 					LanguageUtil.get(httpServletRequest, "folder"));
@@ -180,5 +183,6 @@ public class RepositoryBrowserManagementToolbarDisplayContext
 		_folderModelResourcePermission;
 	private final long _repositoryId;
 	private final ThemeDisplay _themeDisplay;
+	private final boolean _viewableByGuest;
 
 }

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
@@ -87,7 +87,8 @@ public class RepositoryBrowserTagDisplayContext {
 		long folderId, HttpServletRequest httpServletRequest,
 		LiferayPortletRequest liferayPortletRequest,
 		LiferayPortletResponse liferayPortletResponse,
-		PortletRequest portletRequest, long repositoryId, long rootFolderId) {
+		PortletRequest portletRequest, long repositoryId, long rootFolderId,
+		boolean viewableByGuest) {
 
 		_actions = actions;
 		_dlAppService = dlAppService;
@@ -102,6 +103,7 @@ public class RepositoryBrowserTagDisplayContext {
 		_portletRequest = portletRequest;
 		_repositoryId = repositoryId;
 		_rootFolderId = rootFolderId;
+		_viewableByGuest = viewableByGuest;
 
 		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
@@ -190,7 +192,8 @@ public class RepositoryBrowserTagDisplayContext {
 		return new RepositoryBrowserManagementToolbarDisplayContext(
 			_actions, _folderId, _folderModelResourcePermission,
 			_httpServletRequest, _liferayPortletRequest,
-			_liferayPortletResponse, _repositoryId, getSearchContainer());
+			_liferayPortletResponse, _repositoryId, getSearchContainer(),
+			_viewableByGuest);
 	}
 
 	public Map<String, Object> getRepositoryBrowserComponentContext() {
@@ -200,6 +203,8 @@ public class RepositoryBrowserTagDisplayContext {
 			"repositoryBrowserURL", _getRepositoryBrowserURL()
 		).put(
 			"repositoryId", String.valueOf(_repositoryId)
+		).put(
+			"viewableByGuest", String.valueOf(_viewableByGuest)
 		).build();
 	}
 
@@ -713,5 +718,6 @@ public class RepositoryBrowserTagDisplayContext {
 	private final long _rootFolderId;
 	private SearchContainer<Object> _searchContainer;
 	private final ThemeDisplay _themeDisplay;
+	private final boolean _viewableByGuest;
 
 }

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/servlet/RepositoryBrowserServlet.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/servlet/RepositoryBrowserServlet.java
@@ -180,6 +180,9 @@ public class RepositoryBrowserServlet extends HttpServlet {
 				return;
 			}
 
+			boolean viewableByGuest = ParamUtil.getBoolean(
+				httpServletRequest, "viewableByGuest");
+
 			UploadServletRequest uploadServletRequest =
 				_portal.getUploadServletRequest(httpServletRequest);
 
@@ -198,8 +201,10 @@ public class RepositoryBrowserServlet extends HttpServlet {
 					ServiceContextFactory.getInstance(
 						FileEntry.class.getName(), httpServletRequest);
 
-				serviceContext.setAddGroupPermissions(true);
-				serviceContext.setAddGuestPermissions(true);
+				if (viewableByGuest) {
+					serviceContext.setAddGroupPermissions(true);
+					serviceContext.setAddGuestPermissions(true);
+				}
 
 				_dlAppService.addFileEntry(
 					null, repositoryId, parentFolderId, sourceFileName,
@@ -225,10 +230,17 @@ public class RepositoryBrowserServlet extends HttpServlet {
 			long parentFolderId = ParamUtil.getLong(
 				httpServletRequest, "parentFolderId");
 
+			ServiceContext serviceContext = ServiceContextFactory.getInstance(
+				Folder.class.getName(), httpServletRequest);
+
+			if (viewableByGuest) {
+				serviceContext.setAddGroupPermissions(true);
+				serviceContext.setAddGuestPermissions(true);
+			}
+
 			_dlAppService.addFolder(
 				null, repositoryId, parentFolderId, name, StringPool.BLANK,
-				ServiceContextFactory.getInstance(
-					Folder.class.getName(), httpServletRequest));
+				serviceContext);
 
 			SessionMessages.add(
 				httpServletRequest, "requestProcessed",

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/servlet/taglib/RepositoryBrowserTag.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/servlet/taglib/RepositoryBrowserTag.java
@@ -55,6 +55,10 @@ public class RepositoryBrowserTag extends IncludeTag {
 		return _repositoryId;
 	}
 
+	public boolean isViewableByGuest() {
+		return _viewableByGuest;
+	}
+
 	public void setActions(String actions) {
 		_actions = actions;
 	}
@@ -74,6 +78,10 @@ public class RepositoryBrowserTag extends IncludeTag {
 		_repositoryId = repositoryId;
 	}
 
+	public void setViewableByGuest(boolean viewableByGuest) {
+		_viewableByGuest = viewableByGuest;
+	}
+
 	@Override
 	protected void cleanUp() {
 		super.cleanUp();
@@ -81,6 +89,7 @@ public class RepositoryBrowserTag extends IncludeTag {
 		_actions = StringPool.BLANK;
 		_folderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
 		_repositoryId = 0;
+		_viewableByGuest = false;
 	}
 
 	@Override
@@ -111,7 +120,8 @@ public class RepositoryBrowserTag extends IncludeTag {
 				_getFolderId(), httpServletRequest,
 				PortalUtil.getLiferayPortletRequest(portletRequest),
 				PortalUtil.getLiferayPortletResponse(portletResponse),
-				portletRequest, _getRepositoryId(), getFolderId()));
+				portletRequest, _getRepositoryId(), getFolderId(),
+				isViewableByGuest()));
 	}
 
 	private Set<String> _getActionsSet() {
@@ -160,5 +170,6 @@ public class RepositoryBrowserTag extends IncludeTag {
 	private String _actions = StringPool.BLANK;
 	private long _folderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
 	private long _repositoryId;
+	private boolean _viewableByGuest;
 
 }

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/liferay-document-library.tld
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/liferay-document-library.tld
@@ -47,6 +47,11 @@
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
+		<attribute>
+			<name>viewableByGuest</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
 	</tag>
 	<tag>
 		<description>Creates a progress bar for items being uploaded.</description>

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/js/repository_browser/RepositoryBrowserComponent.js
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/js/repository_browser/RepositoryBrowserComponent.js
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
@@ -10,6 +10,7 @@ export default function RepositoryBrowserComponent({
 	parentFolderId,
 	repositoryBrowserURL,
 	repositoryId,
+	viewableByGuest,
 }) {
 	const fileInput = document.getElementById(`${namespace}file`);
 
@@ -18,7 +19,7 @@ export default function RepositoryBrowserComponent({
 
 		formData.append('file', fileInput.files[0]);
 
-		const uploadFileURL = `${repositoryBrowserURL}?repositoryId=${repositoryId}&parentFolderId=${parentFolderId}`;
+		const uploadFileURL = `${repositoryBrowserURL}?repositoryId=${repositoryId}&parentFolderId=${parentFolderId}&viewableByGuest=${viewableByGuest}`;
 
 		fetch(uploadFileURL, {
 			body: formData,

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/js/repository_browser/RepositoryBrowserManagementToolbarPropsTransformer.js
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/js/repository_browser/RepositoryBrowserManagementToolbarPropsTransformer.js
@@ -18,7 +18,7 @@ function handleCreationMenuClick(
 	repositoryBrowserURL
 ) {
 	if (item?.data?.action === 'addFolder') {
-		const createFolderURL = `${repositoryBrowserURL}?repositoryId=${item.data.repositoryId}&parentFolderId=${item.data.parentFolderId}`;
+		const createFolderURL = `${repositoryBrowserURL}?repositoryId=${item.data.repositoryId}&parentFolderId=${item.data.parentFolderId}&viewableByGuest=${item.data.viewableByGuest}`;
 
 		openSimpleInputModal({
 			dialogTitle: Liferay.Language.get('add-folder'),

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_resources.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_resources.jsp
@@ -14,4 +14,5 @@ FragmentCollectionResourcesDisplayContext fragmentCollectionResourcesDisplayCont
 <liferay-document-library:repository-browser
 	folderId="<%= fragmentCollectionResourcesDisplayContext.getFolderId() %>"
 	repositoryId="<%= fragmentCollectionResourcesDisplayContext.getRepositoryId() %>"
+	viewableByGuest="<%= true %>"
 />


### PR DESCRIPTION
- **LPD-31078 Adds new property for taglib to set guest permissions**
- **LPD-31078 Use the new property and pass it along where needed**
- **LPD-31078 Set permissions according to the param**
- **LPD-31078 Fragment resources should always be visible for guests**
- **LPD-31078 Adds new test module for document-library-taglib**
- **LPD-31078 Adds integration test for viewableByGuest property**
