### PR TITLE
LPD-75864 System does not recognize and preserve Vocabulary and category empty shell statuses in the import process

### DIFF
--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyLocalServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyLocalServiceTest.java
@@ -7,16 +7,20 @@ package com.liferay.asset.categories.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.kernel.exception.NoSuchVocabularyException;
+import com.liferay.asset.kernel.exception.VocabularyVisibilityTypeException;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.model.AssetVocabularyConstants;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.asset.test.util.AssetTestUtil;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
@@ -26,6 +30,7 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
+import java.util.HashMap;
 import java.util.Locale;
 
 import org.junit.Assert;
@@ -51,6 +56,16 @@ public class AssetVocabularyLocalServiceTest {
 	@Before
 	public void setUp() throws Exception {
 		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testAddVocabulary() {
+		AssertUtils.assertFailure(
+			VocabularyVisibilityTypeException.class, null,
+			() -> _assetVocabularyLocalService.addVocabulary(
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
+				RandomTestUtil.randomString(), null, new HashMap<>(), null,
+				null, 3, ServiceContextTestUtil.getServiceContext()));
 	}
 
 	@Test
@@ -118,6 +133,25 @@ public class AssetVocabularyLocalServiceTest {
 			Assert.assertEquals(
 				WorkflowConstants.STATUS_APPROVED, vocabulary.getStatus());
 		}
+	}
+
+	@Test
+	public void testUpdateVocabulary() throws Exception {
+		AssetVocabulary assetVocabulary = AssetTestUtil.addVocabulary(
+			_group.getGroupId());
+
+		AssertUtils.assertFailure(
+			VocabularyVisibilityTypeException.class, null,
+			() -> _assetVocabularyLocalService.updateVocabulary(
+				assetVocabulary.getExternalReferenceCode(),
+				assetVocabulary.getVocabularyId(), null, null, null, 3));
+		AssertUtils.assertFailure(
+			VocabularyVisibilityTypeException.class, null,
+			() -> _assetVocabularyLocalService.updateVocabulary(
+				assetVocabulary.getExternalReferenceCode(),
+				assetVocabulary.getVocabularyId(),
+				RandomTestUtil.randomString(), null, null, null, 3,
+				ServiceContextTestUtil.getServiceContext()));
 	}
 
 	@Inject

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/bnd.bnd
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Admin Taxonomy API
 Bundle-SymbolicName: com.liferay.headless.admin.taxonomy.api
-Bundle-Version: 18.0.2
+Bundle-Version: 18.1.0
 Export-Package:\
 	com.liferay.headless.admin.taxonomy.dto.v1_0,\
 	com.liferay.headless.admin.taxonomy.resource.v1_0

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/TaxonomyVocabulary.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/TaxonomyVocabulary.java
@@ -1432,7 +1432,7 @@ public class TaxonomyVocabulary implements Serializable {
 	@GraphQLName("VisibilityType")
 	public static enum VisibilityType {
 
-		PUBLIC("PUBLIC"), INTERNAL("INTERNAL");
+		PUBLIC("PUBLIC"), INTERNAL("INTERNAL"), EMPTY("EMPTY");
 
 		@JsonCreator
 		public static VisibilityType create(String value) {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/resources/com/liferay/headless/admin/taxonomy/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/resources/com/liferay/headless/admin/taxonomy/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 5.7.0
+version 5.8.0

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/dto/v1_0/TaxonomyVocabulary.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/dto/v1_0/TaxonomyVocabulary.java
@@ -565,7 +565,7 @@ public class TaxonomyVocabulary implements Cloneable, Serializable {
 
 	public static enum VisibilityType {
 
-		PUBLIC("PUBLIC"), INTERNAL("INTERNAL");
+		PUBLIC("PUBLIC"), INTERNAL("INTERNAL"), EMPTY("EMPTY");
 
 		public static VisibilityType create(String value) {
 			for (VisibilityType visibilityType : values()) {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi.yaml
@@ -457,7 +457,7 @@ components:
                 visibilityType:
                     description:
                         The vocabulary's visibility type.
-                    enum: [PUBLIC, INTERNAL]
+                    enum: [PUBLIC, INTERNAL, EMPTY]
                     type: string
             required:
                 -   name

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
@@ -211,10 +211,6 @@ public class TaxonomyVocabularyResourceImpl
 				assetVocabulary.getGroupId());
 		}
 
-		boolean internalVisibilityType =
-			TaxonomyVocabulary.VisibilityType.INTERNAL.equals(
-				taxonomyVocabulary.getVisibilityType());
-
 		assetVocabulary = _assetVocabularyService.updateVocabulary(
 			taxonomyVocabulary.getExternalReferenceCode(),
 			assetVocabulary.getVocabularyId(), null,
@@ -232,9 +228,7 @@ public class TaxonomyVocabularyResourceImpl
 				assetTypes, assetVocabulary.getGroupId(),
 				GetterUtil.getBoolean(
 					taxonomyVocabulary.getMultiValued(), true)),
-			internalVisibilityType ?
-				AssetVocabularyConstants.VISIBILITY_TYPE_INTERNAL :
-					AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC,
+			_getVisibilityType(taxonomyVocabulary.getVisibilityType()),
 			ServiceContextBuilder.create(
 				assetVocabulary.getGroupId(), contextHttpServletRequest,
 				taxonomyVocabulary.getViewableByAsString()
@@ -508,10 +502,6 @@ public class TaxonomyVocabularyResourceImpl
 			true, LocaleUtil.getSiteDefault(), "Taxonomy vocabulary", titleMap,
 			new HashSet<>(descriptionMap.keySet()));
 
-		boolean internalVisibilityType =
-			TaxonomyVocabulary.VisibilityType.INTERNAL.equals(
-				taxonomyVocabulary.getVisibilityType());
-
 		return _assetVocabularyService.addVocabulary(
 			externalReferenceCode, siteId,
 			titleMap.get(LocaleUtil.getSiteDefault()), null, titleMap,
@@ -520,9 +510,7 @@ public class TaxonomyVocabularyResourceImpl
 				taxonomyVocabulary.getAssetTypes(), siteId,
 				GetterUtil.getBoolean(
 					taxonomyVocabulary.getMultiValued(), true)),
-			internalVisibilityType ?
-				AssetVocabularyConstants.VISIBILITY_TYPE_INTERNAL :
-					AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC,
+			_getVisibilityType(taxonomyVocabulary.getVisibilityType()),
 			ServiceContextBuilder.create(
 				siteId, contextHttpServletRequest,
 				taxonomyVocabulary.getViewableByAsString()
@@ -904,6 +892,20 @@ public class TaxonomyVocabularyResourceImpl
 						document.get(Field.ASSET_VOCABULARY_ID)))));
 	}
 
+	private int _getVisibilityType(
+		TaxonomyVocabulary.VisibilityType visibilityType) {
+
+		if (TaxonomyVocabulary.VisibilityType.EMPTY.equals(visibilityType)) {
+			return AssetVocabularyConstants.VISIBILITY_TYPE_EMPTY;
+		}
+
+		if (TaxonomyVocabulary.VisibilityType.INTERNAL.equals(visibilityType)) {
+			return AssetVocabularyConstants.VISIBILITY_TYPE_INTERNAL;
+		}
+
+		return AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC;
+	}
+
 	private TaxonomyVocabulary _toTaxonomyVocabulary(
 		AssetVocabulary assetVocabulary) {
 
@@ -979,9 +981,26 @@ public class TaxonomyVocabularyResourceImpl
 						return GroupUtil.getSiteId(group);
 					});
 				setVisibilityType(
-					() -> (assetVocabulary.getVisibilityType() == 1) ?
-						TaxonomyVocabulary.VisibilityType.INTERNAL :
-							TaxonomyVocabulary.VisibilityType.PUBLIC);
+					() -> {
+						int visibilityType =
+							assetVocabulary.getVisibilityType();
+
+						if (visibilityType ==
+								AssetVocabularyConstants.
+									VISIBILITY_TYPE_EMPTY) {
+
+							return TaxonomyVocabulary.VisibilityType.EMPTY;
+						}
+
+						if (visibilityType ==
+								AssetVocabularyConstants.
+									VISIBILITY_TYPE_INTERNAL) {
+
+							return TaxonomyVocabulary.VisibilityType.INTERNAL;
+						}
+
+						return TaxonomyVocabulary.VisibilityType.PUBLIC;
+					});
 			}
 		};
 	}
@@ -1013,10 +1032,6 @@ public class TaxonomyVocabularyResourceImpl
 				_getAssetLibraryGroupIds(taxonomyVocabulary));
 		}
 
-		boolean internalVisibilityType =
-			TaxonomyVocabulary.VisibilityType.INTERNAL.equals(
-				taxonomyVocabulary.getVisibilityType());
-
 		return _assetVocabularyService.updateVocabulary(
 			taxonomyVocabulary.getExternalReferenceCode(),
 			assetVocabulary.getVocabularyId(), null, titleMap, descriptionMap,
@@ -1024,9 +1039,7 @@ public class TaxonomyVocabularyResourceImpl
 				taxonomyVocabulary.getAssetTypes(),
 				assetVocabulary.getGroupId(),
 				taxonomyVocabulary.getMultiValued()),
-			internalVisibilityType ?
-				AssetVocabularyConstants.VISIBILITY_TYPE_INTERNAL :
-					AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC,
+			_getVisibilityType(taxonomyVocabulary.getVisibilityType()),
 			ServiceContextBuilder.create(
 				assetVocabulary.getGroupId(), contextHttpServletRequest,
 				taxonomyVocabulary.getViewableByAsString()

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
@@ -245,6 +245,24 @@ public class TaxonomyVocabularyResourceTest
 		_testGetTaxonomyVocabularyWithoutPermissionsAction();
 	}
 
+	@Test
+	public void testPostSiteTaxonomyVocabulary() throws Exception {
+		super.testPostSiteTaxonomyVocabulary();
+
+		TaxonomyVocabulary randomTaxonomyVocabulary =
+			randomTaxonomyVocabulary();
+
+		randomTaxonomyVocabulary.setVisibilityType(
+			TaxonomyVocabulary.VisibilityType.EMPTY);
+
+		TaxonomyVocabulary postTaxonomyVocabulary =
+			testPostSiteTaxonomyVocabulary_addTaxonomyVocabulary(
+				randomTaxonomyVocabulary);
+
+		assertEquals(randomTaxonomyVocabulary, postTaxonomyVocabulary);
+		assertValid(postTaxonomyVocabulary);
+	}
+
 	@Override
 	@Test
 	public void testPutTaxonomyVocabulary() throws Exception {

--- a/portal-impl/src/com/liferay/portlet/asset/service.xml
+++ b/portal-impl/src/com/liferay/portlet/asset/service.xml
@@ -366,5 +366,6 @@
 		<exception>DuplicateVocabularyExternalReferenceCode</exception>
 		<exception>InvalidAssetCategory</exception>
 		<exception>VocabularyName</exception>
+		<exception>VocabularyVisibilityType</exception>
 	</exceptions>
 </service-builder>

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
@@ -8,6 +8,7 @@ package com.liferay.portlet.asset.service.impl;
 import com.liferay.asset.kernel.exception.DuplicateVocabularyException;
 import com.liferay.asset.kernel.exception.DuplicateVocabularyExternalReferenceCodeException;
 import com.liferay.asset.kernel.exception.VocabularyNameException;
+import com.liferay.asset.kernel.exception.VocabularyVisibilityTypeException;
 import com.liferay.asset.kernel.model.AssetCategoryConstants;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.model.AssetVocabularyConstants;
@@ -44,6 +45,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.permission.ModelPermissions;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -180,6 +182,8 @@ public class AssetVocabularyLocalServiceImpl
 		name = _getVocabularyName(name);
 
 		validate(groupId, name);
+
+		_validateVisibilityType(visibilityType);
 
 		long vocabularyId = counterLocalService.increment();
 
@@ -503,6 +507,8 @@ public class AssetVocabularyLocalServiceImpl
 			String settings, int visibilityType)
 		throws PortalException {
 
+		_validateVisibilityType(visibilityType);
+
 		AssetVocabulary vocabulary =
 			assetVocabularyPersistence.findByPrimaryKey(vocabularyId);
 
@@ -532,6 +538,8 @@ public class AssetVocabularyLocalServiceImpl
 			Map<Locale, String> titleMap, Map<Locale, String> descriptionMap,
 			String settings, int visibilityType, ServiceContext serviceContext)
 		throws PortalException {
+
+		_validateVisibilityType(visibilityType);
 
 		AssetVocabulary vocabulary =
 			assetVocabularyPersistence.findByPrimaryKey(vocabularyId);
@@ -699,6 +707,20 @@ public class AssetVocabularyLocalServiceImpl
 					externalReferenceCode, " in group ", groupId));
 		}
 	}
+
+	private void _validateVisibilityType(int visibilityType)
+		throws PortalException {
+
+		if (!ArrayUtil.contains(_VISIBILITY_TYPES, visibilityType)) {
+			throw new VocabularyVisibilityTypeException();
+		}
+	}
+
+	private static final int[] _VISIBILITY_TYPES = {
+		AssetVocabularyConstants.VISIBILITY_TYPE_EMPTY,
+		AssetVocabularyConstants.VISIBILITY_TYPE_INTERNAL,
+		AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC
+	};
 
 	@BeanReference(type = AssetCategoryLocalService.class)
 	private AssetCategoryLocalService _assetCategoryLocalService;

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
@@ -211,7 +211,10 @@ public class AssetVocabularyLocalServiceImpl
 		vocabulary.setSettings(settings);
 		vocabulary.setVisibilityType(visibilityType);
 
-		if (EmptyModelManagerUtil.isEmptyModel()) {
+		if (EmptyModelManagerUtil.isEmptyModel() ||
+			(visibilityType ==
+				AssetVocabularyConstants.VISIBILITY_TYPE_EMPTY)) {
+
 			vocabulary.setStatus(WorkflowConstants.STATUS_EMPTY);
 		}
 		else {

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 178.0.1
+Bundle-Version: 178.1.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/asset/kernel/exception/VocabularyVisibilityTypeException.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/exception/VocabularyVisibilityTypeException.java
@@ -1,0 +1,30 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.kernel.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class VocabularyVisibilityTypeException extends PortalException {
+
+	public VocabularyVisibilityTypeException() {
+	}
+
+	public VocabularyVisibilityTypeException(String msg) {
+		super(msg);
+	}
+
+	public VocabularyVisibilityTypeException(String msg, Throwable throwable) {
+		super(msg, throwable);
+	}
+
+	public VocabularyVisibilityTypeException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/portal-kernel/src/com/liferay/asset/kernel/exception/packageinfo
+++ b/portal-kernel/src/com/liferay/asset/kernel/exception/packageinfo
@@ -1,1 +1,1 @@
-version 4.2.0
+version 4.3.0


### PR DESCRIPTION
System does not recognize and preserve Vocabulary and category empty shell statuses in the import process

**Includes requested changes** in https://github.com/brianchandotcom/liferay-portal/pull/169404#issuecomment-3759936962

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-75864)

Empty vocabulary is not preserved during exporting/importing

# How am I fixing it?

There are several things to note about this PR. 

First, we have added a check for visibility type that should have been there since the beginning. We only have 3 types, and we didn't check them during adding or updating the vocabularies.

The second one is that the status also depends on the visibility type, so we have to control it.

The third issue was that we had an inconsistency at headless level, we were not taking the empty visibility into account, and when retrieving the empty vocabularies, they were shown as public. So this is also fixed

# How can you verify that it works?

Run the provided integration tests and follow the steps in the ticket
